### PR TITLE
Fix bugs in MetaTxModule.test

### DIFF
--- a/test/modules/MetaTxModule.test.js
+++ b/test/modules/MetaTxModule.test.js
@@ -47,7 +47,7 @@ contract('MetaTxModule', function ([_, owner, address1, address2, address3, trus
       this.domain = {
         name: NAME,
         version: VERSION,
-        chainId: 1,
+        chainId: await web3.eth.getChainId(),
         verifyingContract: this.forwarder.address,
       };
       this.types = {


### PR DESCRIPTION
We must use the chain ID of the current connected node. 
See the documentation : [website](https://web3js.readthedocs.io/en/v1.2.4/web3-eth.html#getchainid)
See OpenZeppelin test : [website](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/test/metatx/MinimalForwarder.test.js)