### PR TITLE
Change type of restrictionCode for uint256

### DIFF
--- a/contracts/CMTAT.sol
+++ b/contracts/CMTAT.sol
@@ -206,7 +206,7 @@ contract CMTAT is
         address from,
         address to,
         uint256 amount
-    ) public view returns (uint8 code) {
+    ) public view returns (uint256 code) {
         if (paused()) {
             return TRANSFER_REJECTED_PAUSED;
         } else if (frozen(from)) {

--- a/contracts/interfaces/IRule.sol
+++ b/contracts/interfaces/IRule.sol
@@ -13,14 +13,14 @@ interface IRule {
         address _from,
         address _to,
         uint256 _amount
-    ) external view returns (uint8);
+    ) external view returns (uint256);
 
-    function canReturnTransferRestrictionCode(uint8 _restrictionCode)
+    function canReturnTransferRestrictionCode(uint256 _restrictionCode)
         external
         view
         returns (bool);
 
-    function messageForTransferRestriction(uint8 _restrictionCode)
+    function messageForTransferRestriction(uint256 _restrictionCode)
         external
         view
         returns (string memory);

--- a/contracts/interfaces/IRuleEngine.sol
+++ b/contracts/interfaces/IRuleEngine.sol
@@ -24,9 +24,9 @@ interface IRuleEngine {
         address _from,
         address _to,
         uint256 _value
-    ) external view returns (uint8);
+    ) external view returns (uint256);
 
-    function messageForTransferRestriction(uint8 _restrictionCode)
+    function messageForTransferRestriction(uint256 _restrictionCode)
         external
         view
         returns (string memory);

--- a/contracts/mocks/RuleEngineMock.sol
+++ b/contracts/mocks/RuleEngineMock.sol
@@ -34,9 +34,9 @@ contract RuleEngineMock is IRuleEngine {
         address _from,
         address _to,
         uint256 _amount
-    ) public view override returns (uint8) {
+    ) public view override returns (uint256) {
         for (uint256 i = 0; i < _rules.length; i++) {
-            uint8 restriction = _rules[i].detectTransferRestriction(
+            uint256 restriction = _rules[i].detectTransferRestriction(
                 _from,
                 _to,
                 _amount
@@ -56,7 +56,7 @@ contract RuleEngineMock is IRuleEngine {
         return detectTransferRestriction(_from, _to, _amount) == 0;
     }
 
-    function messageForTransferRestriction(uint8 _restrictionCode)
+    function messageForTransferRestriction(uint256 _restrictionCode)
         public
         view
         override

--- a/contracts/mocks/RuleMock.sol
+++ b/contracts/mocks/RuleMock.sol
@@ -22,11 +22,11 @@ contract RuleMock is IRule {
         address, /* _from */
         address, /* _to */
         uint256 _amount
-    ) public pure override returns (uint8) {
+    ) public pure override returns (uint256) {
         return _amount < 20 ? 0 : AMOUNT_TOO_HIGH;
     }
 
-    function canReturnTransferRestrictionCode(uint8 _restrictionCode)
+    function canReturnTransferRestrictionCode(uint256 _restrictionCode)
         public
         pure
         override
@@ -35,7 +35,7 @@ contract RuleMock is IRule {
         return _restrictionCode == AMOUNT_TOO_HIGH;
     }
 
-    function messageForTransferRestriction(uint8 _restrictionCode)
+    function messageForTransferRestriction(uint256 _restrictionCode)
         external
         pure
         override

--- a/contracts/modules/ValidationModule.sol
+++ b/contracts/modules/ValidationModule.sol
@@ -57,7 +57,7 @@ abstract contract ValidationModule is Initializable, ContextUpgradeable {
         address from,
         address to,
         uint256 amount
-    ) internal view returns (uint8) {
+    ) internal view returns (uint256) {
         return ruleEngine.detectTransferRestriction(from, to, amount);
     }
 


### PR DESCRIPTION
See audit report, CVF-73

> Description Types narrower than 256 bits don’t save gas when used with function arguments or return values, however they limit the range of possible values.
> 
> Recommendation Consider using the “uint256” type instead of “uint8”.