### PR TITLE
Fix CVF-27, CVF-48, CVF-55

### DIFF
--- a/contracts/CMTAT.sol
+++ b/contracts/CMTAT.sol
@@ -30,7 +30,7 @@ contract CMTAT is
     MetaTxModule,
     SnapshotModule
 {
-    uint8 constant TRANSFER_OK = 0;
+    enum REJECTED_CODE { TRANSFER_OK, TRANSFER_REJECTED_PAUSED, TRANSFER_REJECTED_FROZEN }
     string constant TEXT_TRANSFER_OK = "No restriction";
 
     constructor(
@@ -208,13 +208,13 @@ contract CMTAT is
         uint256 amount
     ) public view returns (uint8 code) {
         if (paused()) {
-            return TRANSFER_REJECTED_PAUSED;
+            return uint8 (REJECTED_CODE.TRANSFER_REJECTED_PAUSED);
         } else if (frozen(from)) {
-            return TRANSFER_REJECTED_FROZEN;
+            return uint8 (REJECTED_CODE.TRANSFER_REJECTED_FROZEN);
         } else if (address(ruleEngine) != address(0)) {
             return _detectTransferRestriction(from, to, amount);
         }
-        return TRANSFER_OK;
+        return uint8 (REJECTED_CODE.TRANSFER_OK);
     }
 
     /**
@@ -227,11 +227,11 @@ contract CMTAT is
         view
         returns (string memory message)
     {
-        if (restrictionCode == TRANSFER_OK) {
+        if (restrictionCode == uint8 (REJECTED_CODE.TRANSFER_OK)) {
             return TEXT_TRANSFER_OK;
-        } else if (restrictionCode == TRANSFER_REJECTED_PAUSED) {
+        } else if (restrictionCode == uint8 (REJECTED_CODE.TRANSFER_REJECTED_PAUSED)) {
             return TEXT_TRANSFER_REJECTED_PAUSED;
-        } else if (restrictionCode == TRANSFER_REJECTED_FROZEN) {
+        } else if (restrictionCode == uint8  (REJECTED_CODE.TRANSFER_REJECTED_FROZEN)) {
             return TEXT_TRANSFER_REJECTED_FROZEN;
         } else if (address(ruleEngine) != address(0)) {
             return _messageForTransferRestriction(restrictionCode);

--- a/contracts/CMTAT.sol
+++ b/contracts/CMTAT.sol
@@ -208,13 +208,13 @@ contract CMTAT is
         uint256 amount
     ) public view returns (uint8 code) {
         if (paused()) {
-            return uint8 (REJECTED_CODE.TRANSFER_REJECTED_PAUSED);
+            return uint8(REJECTED_CODE.TRANSFER_REJECTED_PAUSED);
         } else if (frozen(from)) {
-            return uint8 (REJECTED_CODE.TRANSFER_REJECTED_FROZEN);
+            return uint8(REJECTED_CODE.TRANSFER_REJECTED_FROZEN);
         } else if (address(ruleEngine) != address(0)) {
             return _detectTransferRestriction(from, to, amount);
         }
-        return uint8 (REJECTED_CODE.TRANSFER_OK);
+        return uint8(REJECTED_CODE.TRANSFER_OK);
     }
 
     /**
@@ -227,11 +227,11 @@ contract CMTAT is
         view
         returns (string memory message)
     {
-        if (restrictionCode == uint8 (REJECTED_CODE.TRANSFER_OK)) {
+        if (restrictionCode == uint8(REJECTED_CODE.TRANSFER_OK)) {
             return TEXT_TRANSFER_OK;
-        } else if (restrictionCode == uint8 (REJECTED_CODE.TRANSFER_REJECTED_PAUSED)) {
+        } else if (restrictionCode == uint8(REJECTED_CODE.TRANSFER_REJECTED_PAUSED)) {
             return TEXT_TRANSFER_REJECTED_PAUSED;
-        } else if (restrictionCode == uint8  (REJECTED_CODE.TRANSFER_REJECTED_FROZEN)) {
+        } else if (restrictionCode == uint8(REJECTED_CODE.TRANSFER_REJECTED_FROZEN)) {
             return TEXT_TRANSFER_REJECTED_FROZEN;
         } else if (address(ruleEngine) != address(0)) {
             return _messageForTransferRestriction(restrictionCode);

--- a/contracts/modules/EnforcementModule.sol
+++ b/contracts/modules/EnforcementModule.sol
@@ -29,7 +29,6 @@ abstract contract EnforcementModule is
     mapping(address => bool) private _frozen;
 
     bytes32 public constant ENFORCER_ROLE = keccak256("ENFORCER_ROLE");
-    uint8 internal constant TRANSFER_REJECTED_FROZEN = 2;
     string internal constant TEXT_TRANSFER_REJECTED_FROZEN =
         "All transfers paused";
 

--- a/contracts/modules/PauseModule.sol
+++ b/contracts/modules/PauseModule.sol
@@ -14,7 +14,6 @@ import "../../openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializ
  */
 abstract contract PauseModule is Initializable, PausableUpgradeable {
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
-    uint8 internal constant TRANSFER_REJECTED_PAUSED = 1;
     string internal constant TEXT_TRANSFER_REJECTED_PAUSED =
         "All transfers paused";
 }


### PR DESCRIPTION
From the audit [report ](https://github.com/CMTA/CMTAT/blob/master/doc/audits/ABDK-CMTAT-audit-20210910.pdf)
> **Description:** Defining constants for different transfer rejection reasons in different contracts
is error-prone.
**Recommendation:** Consider using a single enum or define these constants in a single file.