### PR TITLE
Fix CVF-56

### DIFF
--- a/contracts/modules/EnforcementModule.sol
+++ b/contracts/modules/EnforcementModule.sol
@@ -31,7 +31,7 @@ abstract contract EnforcementModule is
     bytes32 public constant ENFORCER_ROLE = keccak256("ENFORCER_ROLE");
     uint8 internal constant TRANSFER_REJECTED_FROZEN = 2;
     string internal constant TEXT_TRANSFER_REJECTED_FROZEN =
-        "All transfers paused";
+        "The address is frozen";
 
     /**
      * @dev Initializes the contract in unpaused state.


### PR DESCRIPTION
Rename text message to fix CVF-56

From the audit [report ](https://github.com/CMTA/CMTAT/blob/master/doc/audits/ABDK-CMTAT-audit-20210910.pdf)

> Description The message is exactly the same as in the “PauseModule” contract. Also, the
message is misleading.
Recommendation Consider changing to something like “Account frozen” or “Transfers for
the account frozen”.