### PR TITLE
OpenZeppelin update 4.8.0

### DIFF
--- a/doc/TOOLCHAIN.md
+++ b/doc/TOOLCHAIN.md
@@ -84,9 +84,9 @@ A wallet implementation
 
 **[OpenZeppelin Contracts Upgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/)**
 Upgradeable variant of OpenZeppelin Contracts, meant for use in upgradeable contracts.
+The version of the library used is available in the file [USAGE.md](./USAGE.md)
 
 Warning: submodules are not automatically updated when the host repository is updated.  
-
 
 ## UML
 

--- a/doc/TOOLCHAIN.md
+++ b/doc/TOOLCHAIN.md
@@ -86,7 +86,9 @@ A wallet implementation
 Upgradeable variant of OpenZeppelin Contracts, meant for use in upgradeable contracts.
 The version of the library used is available in the file [USAGE.md](./USAGE.md)
 
-Warning: submodules are not automatically updated when the host repository is updated.  
+Warning: 
+- Submodules are not automatically updated when the host repository is updated.  
+- Only update the module to a specific version, not an intermediary commit.
 
 ## UML
 

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -10,9 +10,9 @@ are the latest ones that we tested:
 - npm 8.19.2
 - Truffle 5.5.31 (core: 5.5.31)
 - Ganache 7.4.3
-- Solidity 0.8.4 (via solc-js)
+- Solidity 0.8.17 (via solc-js)
 - Node 16.17.0
-- Web3.js 1.7.4
+- Web3.js 1.8.0
 - OpenZeppelin Contracts Upgradeable (submodule) 4.8.0
 
 ## Installation

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -13,6 +13,7 @@ are the latest ones that we tested:
 - Solidity 0.8.4 (via solc-js)
 - Node 16.17.0
 - Web3.js 1.7.4
+- OpenZeppelin Contracts Upgradeable (submodule) 4.8.0
 
 ## Installation
 


### PR DESCRIPTION
Update the OpenZeppelin version to the version 4.8.0, see #96

Fix  [CVF-2, CVF-46, CVF-49, CVF-53, CVF-57, CVF-60, CVF-62](https://github.com/CMTA/CMTAT/pull/98/commits/c0e257671144cf87bd33f241b3e208cfc374e45c) by adding the OpenZeppelin version in the file USAGE.md