### PR TITLE
CVF-54: add the reason parameter

### DIFF
--- a/contracts/modules/internal/EnforcementModuleInternal.sol
+++ b/contracts/modules/internal/EnforcementModuleInternal.sol
@@ -16,19 +16,19 @@ abstract contract EnforcementModuleInternal is
     ContextUpgradeable
 {
     /**
-     * @dev Emitted when an address is frozen.
+     * @notice Emitted when an address is frozen.
      */
     event Freeze(address indexed enforcer, address indexed owner, string indexed reasonIndexed, string reason);
 
     /**
-     * @dev Emitted when an address is unfrozen.
+     * @notice Emitted when an address is unfrozen.
      */
     event Unfreeze(address indexed enforcer, address indexed owner, string indexed reasonIndexed, string reason);
 
     mapping(address => bool) private _frozen;
 
     /**
-     * @dev Initializes the contract in unpaused state.
+     * @dev Initializes the contract
      */
     function __Enforcement_init() internal onlyInitializing {
         __Context_init_unchained();
@@ -40,7 +40,7 @@ abstract contract EnforcementModuleInternal is
     }
 
     /**
-     * @dev Returns true if the contract is paused, and false otherwise.
+     * @dev Returns true if the account is frozen, and false otherwise.
      */
     function frozen(address account) public view virtual returns (bool) {
         return _frozen[account];
@@ -48,7 +48,9 @@ abstract contract EnforcementModuleInternal is
 
     /**
      * @dev Freezes an address.
-     *
+     * @param account the account to freeze
+     * @param reason indicate why the account was frozen. 
+     * 
      */
     function _freeze(address account, string memory reason) internal virtual returns (bool) {
         if (_frozen[account]) return false;
@@ -59,12 +61,14 @@ abstract contract EnforcementModuleInternal is
 
     /**
      * @dev Unfreezes an address.
-     *
+     * @param account the account to unfreeze
+     * @param reason indicate why the account was unfrozen. 
      */
     function _unfreeze(address account, string memory reason) internal virtual returns (bool) {
         if (!_frozen[account]) return false;
         _frozen[account] = false;
         emit Unfreeze(_msgSender(), account, reason, reason);
+        
         return true;
     }
 

--- a/contracts/modules/internal/EnforcementModuleInternal.sol
+++ b/contracts/modules/internal/EnforcementModuleInternal.sol
@@ -18,12 +18,12 @@ abstract contract EnforcementModuleInternal is
     /**
      * @dev Emitted when an address is frozen.
      */
-    event Freeze(address indexed enforcer, address indexed owner);
+    event Freeze(address indexed enforcer, address indexed owner, string indexed reasonIndexed, string reason);
 
     /**
      * @dev Emitted when an address is unfrozen.
      */
-    event Unfreeze(address indexed enforcer, address indexed owner);
+    event Unfreeze(address indexed enforcer, address indexed owner, string indexed reasonIndexed, string reason);
 
     mapping(address => bool) private _frozen;
 
@@ -50,10 +50,10 @@ abstract contract EnforcementModuleInternal is
      * @dev Freezes an address.
      *
      */
-    function _freeze(address account) internal virtual returns (bool) {
+    function _freeze(address account, string memory reason) internal virtual returns (bool) {
         if (_frozen[account]) return false;
         _frozen[account] = true;
-        emit Freeze(_msgSender(), account);
+        emit Freeze(_msgSender(), account, reason, reason);
         return true;
     }
 
@@ -61,10 +61,10 @@ abstract contract EnforcementModuleInternal is
      * @dev Unfreezes an address.
      *
      */
-    function _unfreeze(address account) internal virtual returns (bool) {
+    function _unfreeze(address account, string memory reason) internal virtual returns (bool) {
         if (!_frozen[account]) return false;
         _frozen[account] = false;
-        emit Unfreeze(_msgSender(), account);
+        emit Unfreeze(_msgSender(), account, reason, reason);
         return true;
     }
 

--- a/contracts/modules/internal/SnapshotModuleInternal.sol
+++ b/contracts/modules/internal/SnapshotModuleInternal.sol
@@ -33,6 +33,9 @@ abstract contract SnapshotModuleInternal is
 
     uint256[] private _scheduledSnapshots;
 
+    /**
+     * @dev Initializes the contract
+     */
     function __Snapshot_init(string memory name_, string memory symbol_) internal onlyInitializing {
         __Context_init_unchained();
         __ERC20_init(name_, symbol_);

--- a/contracts/modules/wrapper/mandatory/EnforcementModule.sol
+++ b/contracts/modules/wrapper/mandatory/EnforcementModule.sol
@@ -42,8 +42,9 @@ abstract contract EnforcementModule is EnforcementModuleInternal,
     }
 
     /**
-     * @dev Freezes an address.
-     *
+     * @notice Freezes an address.
+     * @param account the account to freeze
+     * @param reason indicate why the account was frozen. 
      */
     function freeze(address account, string memory reason)
         public
@@ -54,7 +55,10 @@ abstract contract EnforcementModule is EnforcementModuleInternal,
     }
 
     /**
-     * @dev Unfreezes an address.
+     * @notice Unfreezes an address.
+     * @param account the account to unfreeze
+     * @param reason indicate why the account was unfrozen. 
+     *  
      *
      */
     function unfreeze(address account, string memory reason)

--- a/contracts/modules/wrapper/mandatory/EnforcementModule.sol
+++ b/contracts/modules/wrapper/mandatory/EnforcementModule.sol
@@ -45,24 +45,24 @@ abstract contract EnforcementModule is EnforcementModuleInternal,
      * @dev Freezes an address.
      *
      */
-    function freeze(address account)
+    function freeze(address account, string memory reason)
         public
         onlyRole(ENFORCER_ROLE)
         returns (bool)
     {
-        return _freeze(account);
+        return _freeze(account, reason);
     }
 
     /**
      * @dev Unfreezes an address.
      *
      */
-    function unfreeze(address account)
+    function unfreeze(address account, string memory reason)
         public
         onlyRole(ENFORCER_ROLE)
         returns (bool)
     {
-        return _unfreeze(account);
+        return _unfreeze(account, reason);
     }
 
     uint256[50] private __gap;

--- a/test/common/EnforcementModuleCommon.js
+++ b/test/common/EnforcementModuleCommon.js
@@ -2,6 +2,9 @@ const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
 const { ENFORCER_ROLE } = require('../utils')
 
+const reasonFreeze = 'testFreeze'
+const reasonUnfreeze = 'testUnfreeze'
+
 function EnforcementModuleCommon (owner, address1, address2) {
   context('Freeze', function () {
     beforeEach(async function () {
@@ -20,7 +23,9 @@ function EnforcementModuleCommon (owner, address1, address2) {
       // emits a Freeze event
       expectEvent.inLogs(this.logs, 'Freeze', {
         enforcer: owner,
-        owner: address1
+        owner: address1,
+        reasonIndexed: web3.utils.keccak256(reasonFreeze),
+        reason: reasonFreeze
       })
     })
 
@@ -30,13 +35,16 @@ function EnforcementModuleCommon (owner, address1, address2) {
       // Arrange - Assert
       (await this.cmtat.frozen(address1)).should.equal(false);
       // Act
-      ({ logs: this.logs } = await this.cmtat.freeze(address1, { from: address2 }));
+      ({ logs: this.logs } = await this.cmtat.freeze(address1, reasonFreeze, { from: address2 }));
       // Assert
       (await this.cmtat.frozen(address1)).should.equal(true)
+
       // emits a Freeze event
       expectEvent.inLogs(this.logs, 'Freeze', {
         enforcer: address2,
-        owner: address1
+        owner: address1,
+        reasonIndexed: web3.utils.keccak256(reasonFreeze),
+        reason: reasonFreeze
       })
     })
 
@@ -46,14 +54,16 @@ function EnforcementModuleCommon (owner, address1, address2) {
       // Arrange - Assert
       (await this.cmtat.frozen(address1)).should.equal(true);
       // Act
-      ({ logs: this.logs } = await this.cmtat.unfreeze(address1, {
+      ({ logs: this.logs } = await this.cmtat.unfreeze(address1, reasonUnfreeze, {
         from: owner
       }));
       // Assert
       (await this.cmtat.frozen(address1)).should.equal(false)
       expectEvent.inLogs(this.logs, 'Unfreeze', {
         enforcer: owner,
-        owner: address1
+        owner: address1,
+        reasonIndexed: web3.utils.keccak256(reasonUnfreeze),
+        reason: reasonUnfreeze
       })
     })
 
@@ -64,13 +74,15 @@ function EnforcementModuleCommon (owner, address1, address2) {
       // Arrange - Assert
       (await this.cmtat.frozen(address1)).should.equal(true);
       // Act
-      ({ logs: this.logs } = await this.cmtat.unfreeze(address1, { from: address2 }));
+      ({ logs: this.logs } = await this.cmtat.unfreeze(address1, reasonUnfreeze, { from: address2 }));
       // Assert
       (await this.cmtat.frozen(address1)).should.equal(false)
       // emits an Unfreeze event
       expectEvent.inLogs(this.logs, 'Unfreeze', {
         enforcer: address2,
-        owner: address1
+        owner: address1,
+        reasonIndexed: web3.utils.keccak256(reasonUnfreeze),
+        reason: reasonUnfreeze
       })
     })
 

--- a/test/common/EnforcementModuleCommon.js
+++ b/test/common/EnforcementModuleCommon.js
@@ -29,6 +29,25 @@ function EnforcementModuleCommon (owner, address1, address2) {
       })
     })
 
+    it('testReasonParameterCanBeEmptyString', async function () {
+      // Arrange - Assert
+      (await this.cmtat.frozen(address1)).should.equal(false);
+      // Act
+      ({ logs: this.logs } = await this.cmtat.freeze(address1, '', {
+        from: owner
+      }));
+      // Assert
+      (await this.cmtat.frozen(address1)).should.equal(true)
+      // emits a Freeze event
+      expectEvent.inLogs(this.logs, 'Freeze', {
+        enforcer: owner,
+        owner: address1,
+        // see https://ethereum.stackexchange.com/questions/35103/keccak-hash-of-null-values-result-in-different-hashes-for-different-types
+        reasonIndexed: '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        reason: ''
+      })
+    })
+
     it('testEnforcerRoleCanFreezeAddress', async function () {
       // Arrange
       await this.cmtat.grantRole(ENFORCER_ROLE, address2, { from: owner });

--- a/test/common/EnforcementModuleCommon.js
+++ b/test/common/EnforcementModuleCommon.js
@@ -15,7 +15,7 @@ function EnforcementModuleCommon (owner, address1, address2) {
       // Arrange - Assert
       (await this.cmtat.frozen(address1)).should.equal(false);
       // Act
-      ({ logs: this.logs } = await this.cmtat.freeze(address1, {
+      ({ logs: this.logs } = await this.cmtat.freeze(address1, reasonFreeze, {
         from: owner
       }));
       // Assert
@@ -50,7 +50,7 @@ function EnforcementModuleCommon (owner, address1, address2) {
 
     it('testAdminCanUnfreezeAddress', async function () {
       // Arrange
-      await this.cmtat.freeze(address1, { from: owner });
+      await this.cmtat.freeze(address1, reasonFreeze, { from: owner });
       // Arrange - Assert
       (await this.cmtat.frozen(address1)).should.equal(true);
       // Act
@@ -69,7 +69,7 @@ function EnforcementModuleCommon (owner, address1, address2) {
 
     it('testEnforcerRoleCanUnfreezeAddress', async function () {
       // Arrange
-      await this.cmtat.freeze(address1, { from: owner })
+      await this.cmtat.freeze(address1, reasonFreeze, { from: owner })
       await this.cmtat.grantRole(ENFORCER_ROLE, address2, { from: owner });
       // Arrange - Assert
       (await this.cmtat.frozen(address1)).should.equal(true);
@@ -88,7 +88,7 @@ function EnforcementModuleCommon (owner, address1, address2) {
 
     it('testCannotNonEnforcerFreezeAddress', async function () {
       await expectRevert(
-        this.cmtat.freeze(address1, { from: address2 }),
+        this.cmtat.freeze(address1, reasonFreeze, { from: address2 }),
         'AccessControl: account ' +
             address2.toLowerCase() +
             ' is missing role ' +
@@ -100,10 +100,10 @@ function EnforcementModuleCommon (owner, address1, address2) {
 
     it('testCannotNonEnforcerUnfreezeAddress', async function () {
       // Arrange
-      await this.cmtat.freeze(address1, { from: owner })
+      await this.cmtat.freeze(address1, reasonFreeze, { from: owner })
       // Act
       await expectRevert(
-        this.cmtat.unfreeze(address1, { from: address2 }),
+        this.cmtat.unfreeze(address1, reasonUnfreeze, { from: address2 }),
         'AccessControl: account ' +
             address2.toLowerCase() +
             ' is missing role ' +


### PR DESCRIPTION
From the audit report

> `Recommendation These events should probably also have the “reason” parameter.`

```
event Freeze(address indexed enforcer, address indexed owner);
event Unfreeze(address indexed enforcer, address indexed owner);
```

Fix: [commit](https://github.com/CMTA/CMTAT/pull/122/commits/c2d8fce63ea94adce6966b4d5bac592990ca8ec9)