### PR TITLE
3.1/CVF- 2 cmtat deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,18 @@ To use the CMTAT, we recommend that you use the latest audited version, from the
 
 You may modify the token code by adding, removing, or modifying features. However, the base, enforcement, and snapshot modules must remain in place for compliance with Swiss law.
 
-### Proxying support
+### Deployment mode (Standalone / With A Proxy)
+
+#### Standalone
+
+If you want to deploy without a proxy, in standalone mode, you need to use the contract version `CMTAT_STANDALONE`
+
+#### With A Proxy
 
 The CMTAT supports deployment via a proxy contract.  Furthermore, using a proxy permits to upgrade the contract, using a standard proxy upgrade
 pattern.
 
-At deployment, the parameter  `deployedWithProxyIrrevocable_` inside the  CMTAT contract constructor has to be set at true
+The contract version to use as an implementation is the `CMTAT_PROXY`.
 
 Please see the OpenZeppelin [upgradeable contracts documentation](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable) for more information about the proxy requirements applied to the contract.
 

--- a/contracts/CMTAT_PROXY.sol
+++ b/contracts/CMTAT_PROXY.sol
@@ -7,7 +7,7 @@ import "./modules/CMTAT_BASE.sol";
 contract CMTAT_PROXY is CMTAT_BASE
 {
     /** 
-    @notice create the contract
+    @notice Contract version for the deployment with a proxy
     @param forwarderIrrevocable address of the forwarder, required for the gasless support
     */
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/CMTAT_PROXY.sol
+++ b/contracts/CMTAT_PROXY.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: MPL-2.0
+
+pragma solidity ^0.8.17;
+
+import "./modules/CMTAT_BASE.sol";
+
+contract CMTAT_PROXY is CMTAT_BASE
+{
+    /** 
+    @notice create the contract
+    @param forwarderIrrevocable address of the forwarder, required for the gasless support
+    */
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address forwarderIrrevocable
+    ) MetaTxModule(forwarderIrrevocable) {
+        // Initialize the variable for the implementation
+        deployedWithProxy = true;
+        // Disable the possibility to initialize the implementation
+        _disableInitializers();
+    }
+
+    uint256[50] private __gap;
+}

--- a/contracts/CMTAT_STANDALONE.sol
+++ b/contracts/CMTAT_STANDALONE.sol
@@ -7,7 +7,7 @@ import "./modules/CMTAT_BASE.sol";
 contract CMTAT_STANDALONE is CMTAT_BASE
 {
     /** 
-    @notice create the contract
+    @notice Contract version for standalone deployment
     @param forwarderIrrevocable address of the forwarder, required for the gasless support
     @param admin address of the admin of contract (Access Control)
     @param nameIrrevocable name of the token

--- a/contracts/CMTAT_STANDALONE.sol
+++ b/contracts/CMTAT_STANDALONE.sol
@@ -45,5 +45,5 @@ contract CMTAT_STANDALONE is CMTAT_BASE
         );
     }
 
-    uint256[50] private __gap;
+    // No storage gap because the contract is deployed in standalone mode
 }

--- a/contracts/CMTAT_STANDALONE.sol
+++ b/contracts/CMTAT_STANDALONE.sol
@@ -1,0 +1,49 @@
+//SPDX-License-Identifier: MPL-2.0
+
+pragma solidity ^0.8.17;
+
+import "./modules/CMTAT_BASE.sol";
+
+contract CMTAT_STANDALONE is CMTAT_BASE
+{
+    /** 
+    @notice create the contract
+    @param forwarderIrrevocable address of the forwarder, required for the gasless support
+    @param admin address of the admin of contract (Access Control)
+    @param nameIrrevocable name of the token
+    @param symbolIrrevocable name of the symbol
+    @param tokenId name of the tokenId
+    @param terms terms associated with the token
+    @param ruleEngine address of the ruleEngine to apply rules to transfers
+    @param information additional information to describe the token
+    @param flag add information under the form of bit(0, 1)
+    */
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address forwarderIrrevocable,
+        address admin,
+        string memory nameIrrevocable,
+        string memory symbolIrrevocable,
+        string memory tokenId,
+        string memory terms,
+        IRuleEngine ruleEngine,
+        string memory information,
+        uint256 flag
+    ) MetaTxModule(forwarderIrrevocable) {
+        // Initialize the contract to avoid front-running
+        // Warning : do not initialize the proxy
+        initialize(
+            false,
+            admin,
+            nameIrrevocable,
+            symbolIrrevocable,
+            tokenId,
+            terms,
+            ruleEngine,
+            information,
+            flag
+        );
+    }
+
+    uint256[50] private __gap;
+}

--- a/contracts/modules/CMTAT_BASE.sol
+++ b/contracts/modules/CMTAT_BASE.sol
@@ -3,23 +3,23 @@
 pragma solidity ^0.8.17;
 
 // required OZ imports here
-import "../openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
-import "../openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol";
-import "./modules/wrapper/mandatory/BaseModule.sol";
-import "./modules/wrapper/mandatory/BurnModule.sol";
-import "./modules/wrapper/mandatory/MintModule.sol";
-import "./modules/wrapper/mandatory/EnforcementModule.sol";
-import "./modules/wrapper/mandatory/ERC20BaseModule.sol";
-import "./modules/wrapper/mandatory/SnapshotModule.sol";
-import "./modules/wrapper/mandatory/PauseModule.sol";
-import "./modules/wrapper/optional/ValidationModule.sol";
-import "./modules/wrapper/optional/MetaTxModule.sol";
-import "./modules/wrapper/optional/DebtModule/DebtBaseModule.sol";
-import "./modules/wrapper/optional/DebtModule/CreditEvents.sol";
-import "./modules/security/AuthorizationModule.sol";
-import "./interfaces/IRuleEngine.sol";
+import "../../openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "../../openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol";
+import "./wrapper/mandatory/BaseModule.sol";
+import "./wrapper/mandatory/BurnModule.sol";
+import "./wrapper/mandatory/MintModule.sol";
+import "./wrapper/mandatory/EnforcementModule.sol";
+import "./wrapper/mandatory/ERC20BaseModule.sol";
+import "./wrapper/mandatory/SnapshotModule.sol";
+import "./wrapper/mandatory/PauseModule.sol";
+import "./wrapper/optional/ValidationModule.sol";
+import "./wrapper/optional/MetaTxModule.sol";
+import "./wrapper/optional/DebtModule/DebtBaseModule.sol";
+import "./wrapper/optional/DebtModule/CreditEvents.sol";
+import "./security/AuthorizationModule.sol";
+import "../interfaces/IRuleEngine.sol";
 
-contract CMTAT is
+abstract contract CMTAT_BASE is
     Initializable,
     ContextUpgradeable,
     BaseModule,
@@ -34,54 +34,6 @@ contract CMTAT is
     DebtBaseModule,
     CreditEvents
 {
-    /** 
-    @notice create the contract
-    @param forwarderIrrevocable address of the forwarder, required for the gasless support
-    @param deployedWithProxyIrrevocable_ true if the contract is deployed with a proxy, false otherwise
-    @param admin address of the admin of contract (Access Control)
-    @param nameIrrevocable name of the token
-    @param symbolIrrevocable name of the symbol
-    @param tokenId name of the tokenId
-    @param terms terms associated with the token
-    @param ruleEngine address of the ruleEngine to apply rules to transfers
-    @param information additional information to describe the token
-    @param flag add information under the form of bit(0, 1)
-    */
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(
-        address forwarderIrrevocable,
-        bool deployedWithProxyIrrevocable_,
-        address admin,
-        string memory nameIrrevocable,
-        string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IRuleEngine ruleEngine,
-        string memory information,
-        uint256 flag
-    ) MetaTxModule(forwarderIrrevocable) {
-        if (!deployedWithProxyIrrevocable_) {
-            // Initialize the contract to avoid front-running
-            // Warning : do not initialize the proxy
-            initialize(
-                deployedWithProxyIrrevocable_,
-                admin,
-                nameIrrevocable,
-                symbolIrrevocable,
-                tokenId,
-                terms,
-                ruleEngine,
-                information,
-                flag
-            );
-        } else {
-            // Initialize the variable for the implementation
-            deployedWithProxy = true;
-            // Disable the possibility to initialize the implementation
-            _disableInitializers();
-        }
-    }
-
     /**
     @notice 
     initialize the proxy contract

--- a/contracts/test/killTest/CMTATKillTest.sol
+++ b/contracts/test/killTest/CMTATKillTest.sol
@@ -40,41 +40,25 @@ contract CMTAT_KILL_TEST is
     DebtBaseModule,
     CreditEvents
 {
+    /** 
+    @notice create the contract
+    @param forwarderIrrevocable address of the forwarder, required for the gasless support
+    */
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
-        address forwarder,
-        bool deployedWithProxyIrrevocable_,
-        address admin,
-        string memory nameIrrevocable,
-        string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IRuleEngine ruleEngine,
-        string memory information,
-        uint256 flag
-    ) MetaTxModule(forwarder) {
-        if (!deployedWithProxyIrrevocable_) {
-            // Initialize the contract to avoid front-running
-            // Warning : do not initialize the proxy
-            initialize(
-                deployedWithProxyIrrevocable_,
-                admin,
-                nameIrrevocable,
-                symbolIrrevocable,
-                tokenId,
-                terms,
-                ruleEngine,
-                information,
-                flag
-            );
-        } else {
-            // Initialize the variable for the implementation
-            deployedWithProxy = true;
-            // Disable the possibility to initialize the implementation
-            _disableInitializers();
-        }
+        address forwarderIrrevocable
+    ) MetaTxModule(forwarderIrrevocable) {
+        // Initialize the variable for the implementation
+        deployedWithProxy = true;
+        // Disable the possibility to initialize the implementation
+        _disableInitializers();
     }
 
+/**
+    @notice 
+    initialize the proxy contract
+    The calls to this function will revert if the contract was deployed without a proxy
+    */
     function initialize(
         bool deployedWithProxyIrrevocable_,
         address admin,
@@ -100,11 +84,8 @@ contract CMTAT_KILL_TEST is
     }
 
     /**
-     * @dev Grants `DEFAULT_ADMIN_ROLE`, `MINTER_ROLE` and `PAUSER_ROLE` to the
-     * account that deploys the contract.
-     *
-     * See {ERC20-constructor}.
-     */
+    @dev calls the different initialize functions from the different modules
+    */
     function __CMTAT_init(
         bool deployedWithProxyIrrevocable_,
         address admin,
@@ -153,12 +134,18 @@ contract CMTAT_KILL_TEST is
         __CMTAT_init_unchained(deployedWithProxyIrrevocable_);
     }
 
+    /**
+    @param deployedWithProxyIrrevocable_ true if the contract is deployed with a proxy, false otherwise
+    */
     function __CMTAT_init_unchained(
         bool deployedWithProxyIrrevocable_
     ) internal onlyInitializing {
         deployedWithProxy = deployedWithProxyIrrevocable_;
     }
 
+    /**
+    @notice Returns the number of decimals used to get its user representation.
+    */
     function decimals()
         public
         view

--- a/test/common/MetaTxModuleCommon.js
+++ b/test/common/MetaTxModuleCommon.js
@@ -6,9 +6,6 @@ const Wallet = require('ethereumjs-wallet').default
 const { DEFAULT_ADMIN_ROLE } = require('../utils')
 const { should } = require('chai').should()
 
-const CMTAT = artifacts.require('CMTAT')
-const MinimalForwarderMock = artifacts.require('MinimalForwarderMock')
-
 const NAME = 'MinimalForwarder'
 const VERSION = '0.0.1'
 const EIP712Domain = [

--- a/test/common/PauseModuleCommon.js
+++ b/test/common/PauseModuleCommon.js
@@ -2,8 +2,6 @@ const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { PAUSER_ROLE } = require('../utils')
 const { should } = require('chai').should()
 
-const CMTAT = artifacts.require('CMTAT')
-
 function PauseModuleCommon (admin, address1, address2, address3) {
   context('Pause', function () {
     /**

--- a/test/common/SnapshotModuleCommon/SnapshotModuleCommonGetNextSnapshot.js
+++ b/test/common/SnapshotModuleCommon/SnapshotModuleCommonGetNextSnapshot.js
@@ -1,7 +1,6 @@
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { SNAPSHOOTER_ROLE } = require('../../utils')
 const { should } = require('chai').should()
-const CMTAT = artifacts.require('CMTAT')
 const { getUnixTimestamp, timeout, checkArraySnapshot } = require('./SnapshotModuleUtils/SnapshotModuleUtils')
 
 function SnapshotModuleCommonGetNextSnapshot (owner, address1, address2, address3) {

--- a/test/common/SnapshotModuleCommon/SnapshotModuleCommonRescheduling.js
+++ b/test/common/SnapshotModuleCommon/SnapshotModuleCommonRescheduling.js
@@ -1,7 +1,6 @@
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { SNAPSHOOTER_ROLE } = require('../../utils')
 const { should } = require('chai').should()
-const CMTAT = artifacts.require('CMTAT')
 const { getUnixTimestamp, checkArraySnapshot } = require('./SnapshotModuleUtils/SnapshotModuleUtils')
 
 function SnapshotModuleCommonRescheduling (owner, address1, address2, address3) {

--- a/test/common/SnapshotModuleCommon/SnapshotModuleCommonScheduling.js
+++ b/test/common/SnapshotModuleCommon/SnapshotModuleCommonScheduling.js
@@ -1,7 +1,6 @@
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { SNAPSHOOTER_ROLE } = require('../../utils')
 const { should } = require('chai').should()
-const CMTAT = artifacts.require('CMTAT')
 const { getUnixTimestamp, timeout, checkArraySnapshot } = require('./SnapshotModuleUtils/SnapshotModuleUtils')
 
 function SnapshotModuleCommonScheduling (owner, address1, address2, address3) {

--- a/test/common/SnapshotModuleCommon/SnapshotModuleCommonUnschedule.js
+++ b/test/common/SnapshotModuleCommon/SnapshotModuleCommonUnschedule.js
@@ -1,7 +1,6 @@
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { SNAPSHOOTER_ROLE } = require('../../utils')
 const { should } = require('chai').should()
-const CMTAT = artifacts.require('CMTAT')
 const { getUnixTimestamp, checkArraySnapshot } = require('./SnapshotModuleUtils/SnapshotModuleUtils')
 
 function SnapshotModuleCommonUnschedule (owner, address1, address2, address3) {

--- a/test/common/ValidationModule/ValidationModuleCommon.js
+++ b/test/common/ValidationModule/ValidationModuleCommon.js
@@ -1,9 +1,9 @@
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
 
-const CMTAT = artifacts.require('CMTAT')
 const RuleEngineMock = artifacts.require('RuleEngineMock')
 const { RULE_MOCK_AMOUNT_MAX, ZERO_ADDRESS } = require('../../utils')
+
 function ValidationModuleCommon (admin, address1, address2, address3, address1InitialBalance, address2InitialBalance, address3InitialBalance) {
   // Transferring with Rule Engine set
   context('RuleEngineTransferTest', function () {

--- a/test/common/ValidationModule/ValidationModuleSetRuleEngineCommon.js
+++ b/test/common/ValidationModule/ValidationModuleSetRuleEngineCommon.js
@@ -2,9 +2,6 @@ const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { DEFAULT_ADMIN_ROLE } = require('../../utils')
 const { should } = require('chai').should()
 
-const CMTAT = artifacts.require('CMTAT')
-const RuleEngineMock = artifacts.require('RuleEngineMock')
-
 function ValidationModuleSetRuleEngineCommon (admin, address1, ruleEngine) {
   context('RuleEngineSetTest', function () {
     it('testCanBeSetByAdmin', async function () {

--- a/test/proxy/general/KillImplementation.test.js
+++ b/test/proxy/general/KillImplementation.test.js
@@ -22,16 +22,7 @@ contract('Proxy - Security Test', function ([_, admin]) {
       {
         initializer: 'initialize',
         constructorArgs: [
-          _,
-          true,
-          admin,
-          'CMTA Token',
-          'CMTAT',
-          'CMTAT_ISIN',
-          'https://cmta.ch',
-          ZERO_ADDRESS,
-          'CMTAT_info',
-          this.flag
+          _
         ]
       }
     )

--- a/test/proxy/general/Proxy.test.js
+++ b/test/proxy/general/Proxy.test.js
@@ -2,9 +2,9 @@ const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
 
 const { deployProxy, upgradeProxy, erc1967 } = require('@openzeppelin/truffle-upgrades')
-const CMTAT1 = artifacts.require('CMTAT')
+const CMTAT1 = artifacts.require('CMTAT_PROXY')
 const { DEFAULT_ADMIN_ROLE } = require('../../utils')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { ZERO_ADDRESS } = require('../../utils')
 contract(
   'Proxy - Security Test',
@@ -12,7 +12,7 @@ contract(
     beforeEach(async function () {
       this.flag = 5
       this.CMTAT_PROXY = await deployProxy(CMTAT1, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], { initializer: 'initialize', 
-      constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag] })
+      constructorArgs: [_] })
       const implementationContractAddress = await erc1967.getImplementationAddress(this.CMTAT_PROXY.address, { from: admin })
       this.implementationContract = await CMTAT.at(implementationContractAddress)
     })

--- a/test/proxy/general/UpgradeProxy.test.js
+++ b/test/proxy/general/UpgradeProxy.test.js
@@ -2,8 +2,8 @@ const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
 
 const { deployProxy, upgradeProxy, erc1967 } = require('@openzeppelin/truffle-upgrades')
-const CMTAT1 = artifacts.require('CMTAT')
-const CMTAT2 = artifacts.require('CMTAT')
+const CMTAT1 = artifacts.require('CMTAT_PROXY')
+const CMTAT2 = artifacts.require('CMTAT_PROXY')
 const { ZERO_ADDRESS } = require('../../utils')
 
 contract('UpgradeableCMTAT - Proxy', function ([_, admin, address1]) {
@@ -15,7 +15,7 @@ contract('UpgradeableCMTAT - Proxy', function ([_, admin, address1]) {
     // With the first version of CMTAT
     this.CMTAT_PROXY = await deployProxy(CMTAT1, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
       initializer: 'initialize',
-      constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+      constructorArgs: [_]
     })
     const implementationContractAddress1 = erc1967.getImplementationAddress(this.CMTAT_PROXY.address, {
       from: admin
@@ -31,7 +31,7 @@ contract('UpgradeableCMTAT - Proxy', function ([_, admin, address1]) {
 
     // Upgrade the proxy with a new implementation contract
     this.upgradeableCMTATV2Instance = await upgradeProxy(this.CMTAT_PROXY.address, CMTAT2, {
-      constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+      constructorArgs: [_]
     })
     // Get the new implementation contract address
     const implementationContractAddress2 = erc1967.getImplementationAddress(this.CMTAT_PROXY.address, {

--- a/test/proxy/modules/AuthorizationModule/AuthorizationModule.test.js
+++ b/test/proxy/modules/AuthorizationModule/AuthorizationModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const AuthorizationModuleCommon = require('../../../common/AuthorizationModule/AuthorizationModuleCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, owner, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, owner, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/AuthorizationModule/TransferAdminship.test.js
+++ b/test/proxy/modules/AuthorizationModule/TransferAdminship.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const TransferAdminshipCommon = require('../../../common/AuthorizationModule/TransferAdminshipCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, oldAdmin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, oldAdmin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/BaseModule.test.js
+++ b/test/proxy/modules/BaseModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const BaseModuleCommon = require('../../common/BaseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/BurnModule.test.js
+++ b/test/proxy/modules/BurnModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const BurnModuleCommon = require('../../common/BurnModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/CreditEventsModule.test.js
+++ b/test/proxy/modules/CreditEventsModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const CreditEventsModuleCommon = require('../../common/CreditEventsModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/DebtModule.test.js
+++ b/test/proxy/modules/DebtModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const DebtModuleCommon = require('../../common/DebtModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/ERC20BaseModule.test.js
+++ b/test/proxy/modules/ERC20BaseModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const ERC20BaseModuleCommon = require('../../common/BaseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/EnforcementModule.test.js
+++ b/test/proxy/modules/EnforcementModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const EnforcementModuleCommon = require('../../common/EnforcementModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/MetaTxModule.test.js
+++ b/test/proxy/modules/MetaTxModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const MinimalForwarderMock = artifacts.require('MinimalForwarderMock')
 const MetaTxModuleCommon = require('../../common/MetaTxModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
@@ -17,7 +17,7 @@ contract(
       await this.trustedForwarder.initialize()
       this.cmtat = await deployProxy(CMTAT, [true, owner, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [this.trustedForwarder.address, true, owner, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [this.trustedForwarder.address]
       })
     })
 

--- a/test/proxy/modules/MintModule.test.js
+++ b/test/proxy/modules/MintModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const MintModuleCommon = require('../../common/MintModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -10,7 +10,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/PauseModule.test.js
+++ b/test/proxy/modules/PauseModule.test.js
@@ -1,5 +1,5 @@
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const PauseModuleCommon = require('../../common/PauseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -8,7 +8,7 @@ contract('Proxy - PauseModule', function ([_, admin, address1, address2, address
     this.flag = 5
     this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
       initializer: 'initialize',
-      constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+      constructorArgs: [_]
     })
     // Mint tokens to test the transfer
     await this.cmtat.mint(address1, 20, {

--- a/test/proxy/modules/SnapshotModule.test.js
+++ b/test/proxy/modules/SnapshotModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const SnapshotModuleCommonGlobal = require('../../common/SnapshotModuleCommon/global/SnapshotModuleMultiplePlannedTest')
 const SnapshotModuleCommonRescheduling = require('../../common/SnapshotModuleCommon/SnapshotModuleCommonRescheduling')
@@ -17,7 +17,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
 

--- a/test/proxy/modules/ValidationModule/ValidationModule.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const ValidationModuleCommon = require('../../../common/ValidationModule/ValidationModuleSetRuleEngineCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
@@ -14,7 +14,7 @@ contract(
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
       await this.cmtat.mint(address1, ADDRESS1_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address2, ADDRESS2_INITIAL_BALANCE, { from: admin })

--- a/test/proxy/modules/ValidationModule/ValidationModuleConstructor.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModuleConstructor.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const ValidationModuleCommon = require('../../../common/ValidationModule/ValidationModuleSetRuleEngineCommon')
 const RuleEngineMock = artifacts.require('RuleEngineMock')
@@ -13,7 +13,7 @@ contract(
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
       await this.cmtat.mint(address1, ADDRESS1_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address2, ADDRESS2_INITIAL_BALANCE, { from: admin })

--- a/test/proxy/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_PROXY')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const ValidationModuleSetRuleEngineCommon = require('../../../common/ValidationModule/ValidationModuleSetRuleEngineCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
@@ -9,7 +9,7 @@ contract(
       this.flag = 5
       this.cmtat = await deployProxy(CMTAT, [true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
-        constructorArgs: [_, true, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+        constructorArgs: [_]
       })
     })
     ValidationModuleSetRuleEngineCommon(admin, address1, fakeRuleEngine)

--- a/test/standard/modules/AuthorizationModule/AuthorizationModule.test.js
+++ b/test/standard/modules/AuthorizationModule/AuthorizationModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const AuthorizationModuleCommon = require('../../../common/AuthorizationModule/AuthorizationModuleCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, address1, address2, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     AuthorizationModuleCommon(admin, address1, address2)

--- a/test/standard/modules/AuthorizationModule/TransferAdminship.test.js
+++ b/test/standard/modules/AuthorizationModule/TransferAdminship.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const TransferAdminshipCommon = require('../../../common/AuthorizationModule/TransferAdminshipCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, oldAdmin, newAdmin, attacker, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, oldAdmin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, oldAdmin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     TransferAdminshipCommon(oldAdmin, newAdmin, attacker)

--- a/test/standard/modules/BaseModule.test.js
+++ b/test/standard/modules/BaseModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const BaseModuleCommon = require('../../common/BaseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     BaseModuleCommon(admin, address1, address2, address3, false)

--- a/test/standard/modules/BurnModule.test.js
+++ b/test/standard/modules/BurnModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const BurnModuleCommon = require('../../common/BurnModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, address1, address2, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     BurnModuleCommon(admin, address1, address2)

--- a/test/standard/modules/CreditEventsModule.test.js
+++ b/test/standard/modules/CreditEventsModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const CreditEventsModuleCommon = require('../../common/CreditEventsModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, attacker, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     CreditEventsModuleCommon(admin, attacker)

--- a/test/standard/modules/DebtModule.test.js
+++ b/test/standard/modules/DebtModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const DebtModuleCommon = require('../../common/DebtModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     DebtModuleCommon(admin, address1, address2, address3, false)

--- a/test/standard/modules/ERC20BaseModule.test.js
+++ b/test/standard/modules/ERC20BaseModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const ERC20BaseModuleCommon = require('../../common/ERC20BaseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     ERC20BaseModuleCommon(admin, address1, address2, address3, false)

--- a/test/standard/modules/EnforcementModule.test.js
+++ b/test/standard/modules/EnforcementModule.test.js
@@ -1,5 +1,5 @@
 
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const EnforcementModuleCommon = require('../../common/EnforcementModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -8,7 +8,7 @@ contract(
   function ([_, admin, address1, address2, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     EnforcementModuleCommon(admin, address1, address2)

--- a/test/standard/modules/MetaTxModule.test.js
+++ b/test/standard/modules/MetaTxModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const MinimalForwarderMock = artifacts.require('MinimalForwarderMock')
 const MetaTxModuleCommon = require('../../common/MetaTxModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
@@ -15,7 +15,7 @@ contract(
       this.flag = 5
       this.trustedForwarder = await MinimalForwarderMock.new()
       this.trustedForwarder.initialize()
-      this.cmtat = await CMTAT.new(this.trustedForwarder.address, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(this.trustedForwarder.address, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     MetaTxModuleCommon(admin, address1)

--- a/test/standard/modules/MintModule.test.js
+++ b/test/standard/modules/MintModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const MintModuleCommon = require('../../common/MintModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 
@@ -7,7 +7,7 @@ contract(
   function ([_, admin, address1, address2, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     MintModuleCommon(admin, address1, address2)

--- a/test/standard/modules/PauseModule.test.js
+++ b/test/standard/modules/PauseModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const PauseModuleCommon = require('../../common/PauseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
 contract(
@@ -6,7 +6,7 @@ contract(
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
       // Mint tokens to test the transfer
       await this.cmtat.mint(address1, 20, {
         from: admin

--- a/test/standard/modules/SnapshotModule.test.js
+++ b/test/standard/modules/SnapshotModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const SnapshotModuleCommonGlobal = require('../../common/SnapshotModuleCommon/global/SnapshotModuleMultiplePlannedTest')
 const SnapshotModuleCommonRescheduling = require('../../common/SnapshotModuleCommon/SnapshotModuleCommonRescheduling')
 const SnapshotModuleCommonScheduling = require('../../common/SnapshotModuleCommon/SnapshotModuleCommonScheduling')
@@ -13,7 +13,7 @@ contract(
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
     SnapshotModuleMultiplePlannedTest(admin, address1, address2, address3)
     SnapshotModuleOnePlannedSnapshotTest(admin, address1, address2, address3)

--- a/test/standard/modules/ValidationModule/ValidationModule.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const ValidationModuleCommon = require('../../../common/ValidationModule/ValidationModuleCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
 const ADDRESS1_INITIAL_BALANCE = 31
@@ -9,7 +9,7 @@ contract(
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
       await this.cmtat.mint(address1, ADDRESS1_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address2, ADDRESS2_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address3, ADDRESS3_INITIAL_BALANCE, { from: admin })

--- a/test/standard/modules/ValidationModule/ValidationModuleConstructor.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModuleConstructor.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const ValidationModuleCommon = require('../../../common/ValidationModule/ValidationModuleCommon')
 const RuleEngineMock = artifacts.require('RuleEngineMock')
 const ADDRESS1_INITIAL_BALANCE = 17
@@ -10,7 +10,7 @@ contract(
     beforeEach(async function () {
       this.flag = 5
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag, { from: randomDeployer })
       await this.cmtat.mint(address1, ADDRESS1_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address2, ADDRESS2_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address3, ADDRESS3_INITIAL_BALANCE, { from: admin })

--- a/test/standard/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT')
+const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const ValidationModuleSetRuleEngineCommon = require('../../../common/ValidationModule/ValidationModuleSetRuleEngineCommon')
 const { ZERO_ADDRESS } = require('../../../utils')
 contract(
@@ -6,7 +6,7 @@ contract(
   function ([_, admin, address1, fakeRuleEngine, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, false, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
     ValidationModuleSetRuleEngineCommon(admin, address1, fakeRuleEngine)
   }


### PR DESCRIPTION
**CVF-2**

> When this argument is true, no other argument is used.  
> Consider implementing two versions of this contract: one for stand-alone deployment, and another for proxy-deployment.  These two contracts may share the same base class.  Such refactoring could simplify the code.

Fix:
Create two main contracts: one for a deployment with a proxy, and one for a standalone deployment.