### PR TITLE
3.1 / CVF-21: remove the redundant part in the path

### DIFF
--- a/contracts/modules/wrapper/mandatory/BaseModule.sol
+++ b/contracts/modules/wrapper/mandatory/BaseModule.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 // required OZ imports here
 import "../../../../openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "../../security/AuthorizationModule.sol";
-import "../../../modules/security/OnlyDelegateCallModule.sol";
+import "../../security/OnlyDelegateCallModule.sol";
 
 abstract contract BaseModule is AuthorizationModule, OnlyDelegateCallModule {
     bool internal deployedWithProxy;


### PR DESCRIPTION
> The "../modules/" part in the path is redundant.

Fix: remove the redundant part as recommended 