### PR TITLE
3.1 / CVF-16, CVF-19, CVF-22, CVF-25: rename events + CVF-17

### DIFF
--- a/contracts/modules/internal/ValidationModuleInternal.sol
+++ b/contracts/modules/internal/ValidationModuleInternal.sol
@@ -18,7 +18,7 @@ abstract contract ValidationModuleInternal is
     /**
      * @dev Emitted when a rule engine is set.
      */
-    event RuleEngineSet(IRuleEngine indexed newRuleEngine);
+    event RuleEngine(IRuleEngine indexed newRuleEngine);
 
     IRuleEngine public ruleEngine;
 
@@ -37,7 +37,7 @@ abstract contract ValidationModuleInternal is
     ) internal onlyInitializing {
         if (address(ruleEngine_) != address(0)) {
             ruleEngine = ruleEngine_;
-            emit RuleEngineSet(ruleEngine);
+            emit RuleEngine(ruleEngine);
         }
     }
 

--- a/contracts/modules/wrapper/mandatory/BaseModule.sol
+++ b/contracts/modules/wrapper/mandatory/BaseModule.sol
@@ -10,13 +10,13 @@ import "../../../modules/security/OnlyDelegateCallModule.sol";
 abstract contract BaseModule is AuthorizationModule, OnlyDelegateCallModule {
     bool internal deployedWithProxy;
     /* Events */
-    event TermSet(string indexed newTermIndexed, string newTerm);
-    event TokenIdSet(string indexed newTokenIdIndexed, string newTokenId);
-    event InformationSet(
+    event Term(string indexed newTermIndexed, string newTerm);
+    event TokenId(string indexed newTokenIdIndexed, string newTokenId);
+    event Information(
         string indexed newInformationIndexed,
         string newInformation
     );
-    event FlagSet(uint256 indexed newFlag);
+    event Flag(uint256 indexed newFlag);
 
     /* Variables */
     string public tokenId;
@@ -70,26 +70,26 @@ abstract contract BaseModule is AuthorizationModule, OnlyDelegateCallModule {
         string memory tokenId_
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         tokenId = tokenId_;
-        emit TokenIdSet(tokenId_, tokenId_);
+        emit TokenId(tokenId_, tokenId_);
     }
 
     function setTerms(
         string memory terms_
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         terms = terms_;
-        emit TermSet(terms_, terms_);
+        emit Term(terms_, terms_);
     }
 
     function setInformation(
         string memory information_
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         information = information_;
-        emit InformationSet(information_, information_);
+        emit Information(information_, information_);
     }
 
     function setFlag(uint256 flag_) public onlyRole(DEFAULT_ADMIN_ROLE) {
         flag = flag_;
-        emit FlagSet(flag_);
+        emit Flag(flag_);
     }
 
     /**

--- a/contracts/modules/wrapper/optional/DebtModule/CreditEvents.sol
+++ b/contracts/modules/wrapper/optional/DebtModule/CreditEvents.sol
@@ -16,9 +16,9 @@ abstract contract CreditEvents is
     CreditEvents public creditEvents;
 
     /* Events */
-    event FlagDefaultSet(bool indexed newFlagDefault);
-    event FlagRedeemedSet(bool indexed newFlagRedeemed);
-    event RatingSet(string indexed newRatingIndexed, string newRating);
+    event FlagDefault(bool indexed newFlagDefault);
+    event FlagRedeemed(bool indexed newFlagRedeemed);
+    event Rating(string indexed newRatingIndexed, string newRating);
 
     function __CreditEvents_init(address admin) internal onlyInitializing {
         /* OpenZeppelin */
@@ -47,9 +47,9 @@ abstract contract CreditEvents is
         string memory rating_
     ) public onlyRole(DEBT_CREDIT_EVENT_ROLE) {
         creditEvents = (CreditEvents(flagDefault_, flagRedeemed_, rating_));
-        emit FlagDefaultSet(flagDefault_);
-        emit FlagRedeemedSet(flagRedeemed_);
-        emit RatingSet(rating_, rating_);
+        emit FlagDefault(flagDefault_);
+        emit FlagRedeemed(flagRedeemed_);
+        emit Rating(rating_, rating_);
     }
 
     function setFlagDefault(
@@ -57,7 +57,7 @@ abstract contract CreditEvents is
     ) public onlyRole(DEBT_CREDIT_EVENT_ROLE) {
         require(flagDefault_ != creditEvents.flagDefault, "Same value");
         creditEvents.flagDefault = flagDefault_;
-        emit FlagDefaultSet(flagDefault_);
+        emit FlagDefault(flagDefault_);
     }
 
     function setFlagRedeemed(
@@ -65,14 +65,14 @@ abstract contract CreditEvents is
     ) public onlyRole(DEBT_CREDIT_EVENT_ROLE) {
         require(flagRedeemed_ != creditEvents.flagRedeemed, "Same value");
         creditEvents.flagRedeemed = flagRedeemed_;
-        emit FlagRedeemedSet(flagRedeemed_);
+        emit FlagRedeemed(flagRedeemed_);
     }
 
     function setRating(
         string memory rating_
     ) public onlyRole(DEBT_CREDIT_EVENT_ROLE) {
         creditEvents.rating = rating_;
-        emit RatingSet(rating_, rating_);
+        emit Rating(rating_, rating_);
     }
 
     uint256[50] private __gap;

--- a/contracts/modules/wrapper/optional/DebtModule/DebtBaseModule.sol
+++ b/contracts/modules/wrapper/optional/DebtModule/DebtBaseModule.sol
@@ -16,42 +16,42 @@ abstract contract DebtBaseModule is
     DebtBase public debt;
 
     /* Events */
-    event InterestRateSet(uint256 indexed newInterestRate);
-    event ParValueSet(uint256 indexed newParValue);
-    event GuarantorSet(string indexed newGuarantorIndexed, string newGuarantor);
-    event BondHolderSet(
+    event InterestRate(uint256 indexed newInterestRate);
+    event ParValue(uint256 indexed newParValue);
+    event Guarantor(string indexed newGuarantorIndexed, string newGuarantor);
+    event BondHolder(
         string indexed newBondHolderIndexed,
         string newBondHolder
     );
-    event MaturityDateSet(
+    event MaturityDate(
         string indexed newMaturityDateIndexed,
         string newMaturityDate
     );
-    event InterestScheduleFormatSet(
+    event InterestScheduleFormat(
         string indexed newInterestScheduleFormatIndexed,
         string newInterestScheduleFormat
     );
-    event InterestPaymentDateSet(
+    event InterestPaymentDate(
         string indexed newInterestPaymentDateIndexed,
         string newInterestPaymentDate
     );
-    event DayCountConventionSet(
+    event DayCountConvention(
         string indexed newDayCountConventionIndexed,
         string newDayCountConvention
     );
-    event BusinessDayConventionSet(
+    event BusinessDayConvention(
         string indexed newBusinessDayConventionIndexed,
         string newBusinessDayConvention
     );
-    event PublicHolidaysCalendarSet(
+    event PublicHolidaysCalendar(
         string indexed newPublicHolidaysCalendarIndexed,
         string newPublicHolidaysCalendar
     );
-    event IssuanceDateSet(
+    event IssuanceDate(
         string indexed newIssuanceDateIndexed,
         string newIssuanceDate
     );
-    event CouponFrequencySet(
+    event CouponFrequency(
         string indexed newCouponFrequencyIndexed,
         string newCouponFrequency
     );
@@ -108,22 +108,22 @@ abstract contract DebtBaseModule is
                 couponFrequency_
             )
         );
-        emit InterestRateSet(interestRate_);
-        emit ParValueSet(parValue_);
-        emit GuarantorSet(guarantor_, guarantor_);
-        emit BondHolderSet(bondHolder_, bondHolder_);
-        emit MaturityDateSet(maturityDate_, maturityDate_);
-        emit InterestScheduleFormatSet(
+        emit InterestRate(interestRate_);
+        emit ParValue(parValue_);
+        emit Guarantor(guarantor_, guarantor_);
+        emit BondHolder(bondHolder_, bondHolder_);
+        emit MaturityDate(maturityDate_, maturityDate_);
+        emit InterestScheduleFormat(
             interestScheduleFormat_,
             interestScheduleFormat_
         );
-        emit InterestPaymentDateSet(interestPaymentDate_, interestPaymentDate_);
-        emit DayCountConventionSet(dayCountConvention_, dayCountConvention_);
-        emit BusinessDayConventionSet(
+        emit InterestPaymentDate(interestPaymentDate_, interestPaymentDate_);
+        emit DayCountConvention(dayCountConvention_, dayCountConvention_);
+        emit BusinessDayConvention(
             businessDayConvention_,
             businessDayConvention_
         );
-        emit PublicHolidaysCalendarSet(
+        emit PublicHolidaysCalendar(
             publicHolidayCalendar_,
             publicHolidayCalendar_
         );
@@ -131,38 +131,38 @@ abstract contract DebtBaseModule is
 
     function setInterestRate(uint256 interestRate_) public onlyRole(DEBT_ROLE) {
         debt.interestRate = interestRate_;
-        emit InterestRateSet(interestRate_);
+        emit InterestRate(interestRate_);
     }
 
     function setParValue(uint256 parValue_) public onlyRole(DEBT_ROLE) {
         debt.parValue = parValue_;
-        emit ParValueSet(parValue_);
+        emit ParValue(parValue_);
     }
 
     function setGuarantor(string memory guarantor_) public onlyRole(DEBT_ROLE) {
         debt.guarantor = guarantor_;
-        emit GuarantorSet(guarantor_, guarantor_);
+        emit Guarantor(guarantor_, guarantor_);
     }
 
     function setBondHolder(
         string memory bondHolder_
     ) public onlyRole(DEBT_ROLE) {
         debt.bondHolder = bondHolder_;
-        emit BondHolderSet(bondHolder_, bondHolder_);
+        emit BondHolder(bondHolder_, bondHolder_);
     }
 
     function setMaturityDate(
         string memory maturityDate_
     ) public onlyRole(DEBT_ROLE) {
         debt.maturityDate = maturityDate_;
-        emit MaturityDateSet(maturityDate_, maturityDate_);
+        emit MaturityDate(maturityDate_, maturityDate_);
     }
 
     function setInterestScheduleFormat(
         string memory interestScheduleFormat_
     ) public onlyRole(DEBT_ROLE) {
         debt.interestScheduleFormat = interestScheduleFormat_;
-        emit InterestScheduleFormatSet(
+        emit InterestScheduleFormat(
             interestScheduleFormat_,
             interestScheduleFormat_
         );
@@ -172,21 +172,21 @@ abstract contract DebtBaseModule is
         string memory interestPaymentDate_
     ) public onlyRole(DEBT_ROLE) {
         debt.interestPaymentDate = interestPaymentDate_;
-        emit InterestPaymentDateSet(interestPaymentDate_, interestPaymentDate_);
+        emit InterestPaymentDate(interestPaymentDate_, interestPaymentDate_);
     }
 
     function setDayCountConvention(
         string memory dayCountConvention_
     ) public onlyRole(DEBT_ROLE) {
         debt.dayCountConvention = dayCountConvention_;
-        emit DayCountConventionSet(dayCountConvention_, dayCountConvention_);
+        emit DayCountConvention(dayCountConvention_, dayCountConvention_);
     }
 
     function setBusinessDayConvention(
         string memory businessDayConvention_
     ) public onlyRole(DEBT_ROLE) {
         debt.businessDayConvention = businessDayConvention_;
-        emit BusinessDayConventionSet(
+        emit BusinessDayConvention(
             businessDayConvention_,
             businessDayConvention_
         );
@@ -196,7 +196,7 @@ abstract contract DebtBaseModule is
         string memory publicHolidayCalendar_
     ) public onlyRole(DEBT_ROLE) {
         debt.publicHolidayCalendar = publicHolidayCalendar_;
-        emit PublicHolidaysCalendarSet(
+        emit PublicHolidaysCalendar(
             publicHolidayCalendar_,
             publicHolidayCalendar_
         );
@@ -206,14 +206,14 @@ abstract contract DebtBaseModule is
         string memory issuanceDate_
     ) public onlyRole(DEBT_ROLE) {
         debt.issuanceDate = issuanceDate_;
-        emit IssuanceDateSet(issuanceDate_, issuanceDate_);
+        emit IssuanceDate(issuanceDate_, issuanceDate_);
     }
 
     function setCouponFrequency(
         string memory couponFrequency_
     ) public onlyRole(DEBT_ROLE) {
         debt.couponFrequency = couponFrequency_;
-        emit CouponFrequencySet(couponFrequency_, couponFrequency_);
+        emit CouponFrequency(couponFrequency_, couponFrequency_);
     }
 
     uint256[50] private __gap;

--- a/contracts/modules/wrapper/optional/DebtModule/DebtBaseModule.sol
+++ b/contracts/modules/wrapper/optional/DebtModule/DebtBaseModule.sol
@@ -16,8 +16,8 @@ abstract contract DebtBaseModule is
     DebtBase public debt;
 
     /* Events */
-    event InterestRate(uint256 indexed newInterestRate);
-    event ParValue(uint256 indexed newParValue);
+    event InterestRate(uint256 newInterestRate);
+    event ParValue(uint256 newParValue);
     event Guarantor(string indexed newGuarantorIndexed, string newGuarantor);
     event BondHolder(
         string indexed newBondHolderIndexed,

--- a/contracts/modules/wrapper/optional/ValidationModule.sol
+++ b/contracts/modules/wrapper/optional/ValidationModule.sol
@@ -60,7 +60,7 @@ abstract contract ValidationModule is
         IRuleEngine ruleEngine_
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         ruleEngine = ruleEngine_;
-        emit RuleEngineSet(ruleEngine_);
+        emit RuleEngine(ruleEngine_);
     }
 
     /**

--- a/test/common/BaseModuleCommon.js
+++ b/test/common/BaseModuleCommon.js
@@ -19,7 +19,7 @@ function BaseModuleCommon (owner, address1, address2, address3, proxyTest) {
       ({ logs: this.logs } = await this.cmtat.setTokenId('CMTAT_TOKENID', { from: owner }));
       // Assert
       (await this.cmtat.tokenId()).should.equal('CMTAT_TOKENID')
-      expectEvent.inLogs(this.logs, 'TokenIdSet', {
+      expectEvent.inLogs(this.logs, 'TokenId', {
         newTokenIdIndexed: web3.utils.sha3('CMTAT_TOKENID'),
         newTokenId: 'CMTAT_TOKENID'
       })
@@ -45,7 +45,7 @@ function BaseModuleCommon (owner, address1, address2, address3, proxyTest) {
       ({ logs: this.logs } = await this.cmtat.setTerms('https://cmta.ch/terms', { from: owner }));
       // Assert
       (await this.cmtat.terms()).should.equal('https://cmta.ch/terms')
-      expectEvent.inLogs(this.logs, 'TermSet', {
+      expectEvent.inLogs(this.logs, 'Term', {
         newTermIndexed: web3.utils.sha3('https://cmta.ch/terms'),
         newTerm: 'https://cmta.ch/terms'
       })
@@ -71,7 +71,7 @@ function BaseModuleCommon (owner, address1, address2, address3, proxyTest) {
       ({ logs: this.logs } = await this.cmtat.setInformation('new info available', { from: owner }));
       // Assert
       (await this.cmtat.information()).should.equal('new info available')
-      expectEvent.inLogs(this.logs, 'InformationSet', {
+      expectEvent.inLogs(this.logs, 'Information', {
         newInformationIndexed: web3.utils.sha3('new info available'),
         newInformation: 'new info available'
       })
@@ -97,7 +97,7 @@ function BaseModuleCommon (owner, address1, address2, address3, proxyTest) {
       ({ logs: this.logs } = await this.cmtat.setFlag(100, { from: owner }));
       // Assert
       (await this.cmtat.flag()).should.be.bignumber.equal('100')
-      expectEvent.inLogs(this.logs, 'FlagSet', {
+      expectEvent.inLogs(this.logs, 'Flag', {
         newFlag: '100'
       })
     })

--- a/test/common/CreditEventsModuleCommon.js
+++ b/test/common/CreditEventsModuleCommon.js
@@ -26,7 +26,7 @@ function CreditEventsModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setFlagDefault(true, { from: owner }));
       // Assert
       (await this.cmtat.creditEvents()).flagDefault.should.equal(true)
-      expectEvent.inLogs(this.logs, 'FlagDefaultSet', {
+      expectEvent.inLogs(this.logs, 'FlagDefault', {
         newFlagDefault: true
       })
     })
@@ -38,7 +38,7 @@ function CreditEventsModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setFlagRedeemed(true, { from: owner }));
       // Assert
       (await this.cmtat.creditEvents()).flagRedeemed.should.equal(true)
-      expectEvent.inLogs(this.logs, 'FlagRedeemedSet', {
+      expectEvent.inLogs(this.logs, 'FlagRedeemed', {
         newFlagRedeemed: true
       })
     })
@@ -50,7 +50,7 @@ function CreditEventsModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setRating('B++', { from: owner }));
       // Assert
       (await this.cmtat.creditEvents()).rating.should.equal('B++')
-      expectEvent.inLogs(this.logs, 'RatingSet', {
+      expectEvent.inLogs(this.logs, 'Rating', {
         newRatingIndexed: web3.utils.sha3('B++'),
         newRating: 'B++'
       })

--- a/test/common/DebtModuleCommon.js
+++ b/test/common/DebtModuleCommon.js
@@ -44,7 +44,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setInterestRate(7, { from: owner }));
       // Assert
       (await this.cmtat.debt()).interestRate.should.be.bignumber.equal('7')
-      expectEvent.inLogs(this.logs, 'InterestRateSet', {
+      expectEvent.inLogs(this.logs, 'InterestRate', {
         newInterestRate: '7'
       })
     })
@@ -56,7 +56,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setParValue(7, { from: owner }));
       // Assert
       (await this.cmtat.debt()).parValue.should.be.bignumber.equal('7')
-      expectEvent.inLogs(this.logs, 'ParValueSet', {
+      expectEvent.inLogs(this.logs, 'ParValue', {
         newParValue: '7'
       })
     })
@@ -68,7 +68,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setGuarantor('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).guarantor.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'GuarantorSet', {
+      expectEvent.inLogs(this.logs, 'Guarantor', {
         newGuarantorIndexed: web3.utils.sha3('Test'),
         newGuarantor: 'Test'
       })
@@ -81,7 +81,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setBondHolder('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).bondHolder.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'BondHolderSet', {
+      expectEvent.inLogs(this.logs, 'BondHolder', {
         newBondHolderIndexed: web3.utils.sha3('Test'),
         newBondHolder: 'Test'
       })
@@ -94,7 +94,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setMaturityDate('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).maturityDate.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'MaturityDateSet', {
+      expectEvent.inLogs(this.logs, 'MaturityDate', {
         newMaturityDateIndexed: web3.utils.sha3('Test'),
         newMaturityDate: 'Test'
       })
@@ -107,7 +107,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setInterestScheduleFormat('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).interestScheduleFormat.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'InterestScheduleFormatSet', {
+      expectEvent.inLogs(this.logs, 'InterestScheduleFormat', {
         newInterestScheduleFormatIndexed: web3.utils.sha3('Test'),
         newInterestScheduleFormat: 'Test'
       })
@@ -120,7 +120,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setInterestPaymentDate('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).interestPaymentDate.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'InterestPaymentDateSet', {
+      expectEvent.inLogs(this.logs, 'InterestPaymentDate', {
         newInterestPaymentDateIndexed: web3.utils.sha3('Test'),
         newInterestPaymentDate: 'Test'
       })
@@ -133,7 +133,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setDayCountConvention('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).dayCountConvention.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'DayCountConventionSet', {
+      expectEvent.inLogs(this.logs, 'DayCountConvention', {
         newDayCountConventionIndexed: web3.utils.sha3('Test'),
         newDayCountConvention: 'Test'
       })
@@ -146,7 +146,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setBusinessDayConvention('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).businessDayConvention.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'BusinessDayConventionSet', {
+      expectEvent.inLogs(this.logs, 'BusinessDayConvention', {
         newBusinessDayConventionIndexed: web3.utils.sha3('Test'),
         newBusinessDayConvention: 'Test'
       })
@@ -159,7 +159,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setPublicHolidaysCalendar('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).publicHolidayCalendar.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'PublicHolidaysCalendarSet', {
+      expectEvent.inLogs(this.logs, 'PublicHolidaysCalendar', {
         newPublicHolidaysCalendarIndexed: web3.utils.sha3('Test'),
         newPublicHolidaysCalendar: 'Test'
       })
@@ -172,7 +172,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setIssuanceDate('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).issuanceDate.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'IssuanceDateSet', {
+      expectEvent.inLogs(this.logs, 'IssuanceDate', {
         newIssuanceDateIndexed: web3.utils.sha3('Test'),
         newIssuanceDate: 'Test'
       })
@@ -185,7 +185,7 @@ function BaseModuleCommon (owner, attacker) {
       ({ logs: this.logs } = await this.cmtat.setCouponFrequency('Test', { from: owner }));
       // Assert
       (await this.cmtat.debt()).couponFrequency.should.equal('Test')
-      expectEvent.inLogs(this.logs, 'CouponFrequencySet', {
+      expectEvent.inLogs(this.logs, 'CouponFrequency', {
         newCouponFrequencyIndexed: web3.utils.sha3('Test'),
         newCouponFrequency: 'Test'
       })

--- a/test/common/ValidationModule/ValidationModuleSetRuleEngineCommon.js
+++ b/test/common/ValidationModule/ValidationModuleSetRuleEngineCommon.js
@@ -14,7 +14,7 @@ function ValidationModuleSetRuleEngineCommon (admin, address1, ruleEngine) {
       }))
       // Assert
       // emits a RuleEngineSet event
-      expectEvent.inLogs(this.logs, 'RuleEngineSet', {
+      expectEvent.inLogs(this.logs, 'RuleEngine', {
         newRuleEngine: ruleEngine
       })
     })


### PR DESCRIPTION
**CVF-16**

> Events are usually named via nouns, such as "InterestRate", "ParValue", etc.

Rename the different events as recommended

**CVF-17**

> Indexing numerical event parameters doesn't make much sense, as indexes could only be used for exact values searches, but not for range searches.  
> Consider not indexing numeric parameters.

Remove the indexation of numeric parameters as recommended

**CVF-19**

> Events are usually named via nouns, such as "DefaultFlag", "RedeemedFlag", or "Rating".

Rename the different events as recommended

**CVF-22**

> Events are usually named via flags, such as "Term", "TokenId", "Information", etc.

Rename the different events as recommended

**CVF-25**

> Events are usually named via nouns, such as "RuleEngine".

Rename the different events as recommended

