### PR TITLE
3.1/CVF-7 & CVF-27: interfaces

### DIFF
--- a/contracts/interfaces/IDebtGlobal.sol
+++ b/contracts/interfaces/IDebtGlobal.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MPL-2.0
 
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 interface IDebtGlobal {
     struct DebtBase {

--- a/contracts/interfaces/IERC1404.sol
+++ b/contracts/interfaces/IERC1404.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MPL-2.0
 
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 interface IERC1404 {
     /**

--- a/contracts/interfaces/IERC1404Wrapper.sol
+++ b/contracts/interfaces/IERC1404Wrapper.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MPL-2.0
 
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "./IERC1404.sol";
 

--- a/contracts/interfaces/IRule.sol
+++ b/contracts/interfaces/IRule.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MPL-2.0
 
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "./IERC1404Wrapper.sol";
 

--- a/contracts/interfaces/IRuleEngine.sol
+++ b/contracts/interfaces/IRuleEngine.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MPL-2.0
 
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "./IRule.sol";
 import "./IERC1404Wrapper.sol";

--- a/contracts/interfaces/IRuleEngine.sol
+++ b/contracts/interfaces/IRuleEngine.sol
@@ -14,7 +14,7 @@ interface IRuleEngine is IERC1404Wrapper {
     /**
      * @dev return the number of rules
      */
-    function ruleLength() external view returns (uint256);
+    function rulesCount() external view returns (uint256);
 
     /**
      * @dev return the rule at the index specified by ruleId

--- a/contracts/mocks/RuleEngineMock.sol
+++ b/contracts/mocks/RuleEngineMock.sol
@@ -18,7 +18,7 @@ contract RuleEngineMock is IRuleEngine, CodeList {
         _rules = rules_;
     }
 
-    function ruleLength() external view override returns (uint256) {
+    function rulesCount() external view override returns (uint256) {
         return _rules.length;
     }
 


### PR DESCRIPTION
**CVF-7**

> Specifying a particular compiler version makes it harder to migrate to newer versions.  This also would make it harder to use this interface in other projects.  
> 
> Consider specifying as "^0.8.0". Also relevant for: IRule.sol, IERC1404Wrapper.sol, IERC1404.sol, IDebtGlobal.sol.

Fix:
For interface, it is indeed relevant to set the version to ^0.8.0

**CVF-27**

> The name sounds odd.  
> Consider renaming to "rulesCount".

Fix:
The function was renamed as recommended