### PR TITLE
AuthorizationModule: add check admin zero address with test

### DIFF
--- a/contracts/CMTAT.sol
+++ b/contracts/CMTAT.sol
@@ -113,6 +113,7 @@ contract CMTAT is
 
     /**
     @dev calls the different initialize functions from the different modules
+    @param admin the address has to be different from 0, check made in AuthorizationModule
     */
     function __CMTAT_init(
         bool deployedWithProxyIrrevocable_,

--- a/contracts/modules/security/AuthorizationModule.sol
+++ b/contracts/modules/security/AuthorizationModule.sol
@@ -43,6 +43,7 @@ abstract contract AuthorizationModule is AccessControlUpgradeable {
     function __AuthorizationModule_init_unchained(
         address admin
     ) internal onlyInitializing {
+        require(admin != address(0), "Address 0 not allowed");
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         grantOtherRoletoAdmin(admin);
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:base": "npx truffle test test/standard/modules/BaseModule.test.js test/proxy/modules/BaseModule.test.js",
     "test:erc20Base": "npx truffle test test/standard/modules/ERC20BaseModule.test.js test/proxy/modules/ERC20BaseModule.test.js",
     "test:debt": "npx truffle test test/standard/modules/DebtModule.test.js test/proxy/modules/DebtModule.test.js",
-    "test:creditEvents": "npx truffle test test/standard/modules/CreditEventsModule.test.js test/proxy/modules/CreditEventsModule.test.js"
+    "test:creditEvents": "npx truffle test test/standard/modules/CreditEventsModule.test.js test/proxy/modules/CreditEventsModule.test.js",
+    "test:deployment": "npx truffle test test/deployment/deployment.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/deployment/deployment.test.js
+++ b/test/deployment/deployment.test.js
@@ -1,0 +1,24 @@
+const { expectRevert } = require('@openzeppelin/test-helpers')
+const CMTAT = artifacts.require('CMTAT')
+const { deployProxy } = require('@openzeppelin/truffle-upgrades')
+const { ZERO_ADDRESS } = require('../utils')
+contract(
+  'CMTAT - Deployment',
+  function ([_], admin) {
+    it('testCannotDeployProxyWithAdminSetToAddressZero', async function () {
+      this.flag = 5
+
+      // Act + Assert
+      await expectRevert(deployProxy(CMTAT, [true, ZERO_ADDRESS, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+        initializer: 'initialize',
+        constructorArgs: [_, true, ZERO_ADDRESS, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag]
+      }), 'Address 0 not allowed')
+    })
+    it('testCannotDeployStandaloneWithAdminSetToAddressZero', async function () {
+      this.flag = 5
+
+      // Act + Assert
+      await expectRevert(CMTAT.new(_, false, ZERO_ADDRESS, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: admin }), 'Address 0 not allowed')
+    })
+  }
+)


### PR DESCRIPTION
Revert if the admin address is the zero address at deployment, check made in Authorization module

#147 