### PR TITLE
Improve rule engine architecture

### DIFF
--- a/contracts/CMTAT_STANDALONE.sol
+++ b/contracts/CMTAT_STANDALONE.sol
@@ -26,7 +26,7 @@ contract CMTAT_STANDALONE is CMTAT_BASE
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) MetaTxModule(forwarderIrrevocable) {

--- a/contracts/interfaces/IEIP1404.sol
+++ b/contracts/interfaces/IEIP1404.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-interface IERC1404 {
+interface IEIP1404 {
     /**
-     * @dev See ERC-1404
+     * @dev See ERC/EIP-1404
      *
      */
     function detectTransferRestriction(
@@ -14,7 +14,7 @@ interface IERC1404 {
     ) external view returns (uint8);
 
     /**
-     * @dev See ERC-1404
+     * @dev See ERC/EIP-1404
      *
      */
     function messageForTransferRestriction(

--- a/contracts/interfaces/IEIP1404Wrapper.sol
+++ b/contracts/interfaces/IEIP1404Wrapper.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "./IERC1404.sol";
+import "./IEIP1404.sol";
 
-interface IERC1404Wrapper is IERC1404 {
+interface IEIP1404Wrapper is IEIP1404 {
     /* 
     @dev leave the code 4-9 free/unused for further additions in your ruleEngine implementation
     */

--- a/contracts/mocks/RuleEngineMock.sol
+++ b/contracts/mocks/RuleEngineMock.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.17;
 
-import "../interfaces/IRule.sol";
-import "../interfaces/IRuleEngine.sol";
+import "./interfaces/IRule.sol";
+import "./interfaces/IRuleEngine.sol";
 import "./RuleMock.sol";
 import "./CodeList.sol";
 

--- a/contracts/mocks/RuleMock.sol
+++ b/contracts/mocks/RuleMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.17;
 
-import "../interfaces/IRule.sol";
+import "./interfaces/IRule.sol";
 import "./CodeList.sol";
 
 contract RuleMock is IRule, CodeList {

--- a/contracts/mocks/interfaces/IRule.sol
+++ b/contracts/mocks/interfaces/IRule.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "./IERC1404Wrapper.sol";
+import "../../interfaces/IERC1404Wrapper.sol";
 
 interface IRule is IERC1404Wrapper {
     /**

--- a/contracts/mocks/interfaces/IRuleEngine.sol
+++ b/contracts/mocks/interfaces/IRuleEngine.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "./IRule.sol";
-import "./IERC1404Wrapper.sol";
+import "../../interfaces/IERC1404Wrapper.sol";
 
 interface IRuleEngine is IERC1404Wrapper {
 

--- a/contracts/modules/CMTAT_BASE.sol
+++ b/contracts/modules/CMTAT_BASE.sol
@@ -22,7 +22,7 @@ import "./wrapper/optional/MetaTxModule.sol";
 import "./wrapper/optional/DebtModule/DebtBaseModule.sol";
 import "./wrapper/optional/DebtModule/CreditEvents.sol";
 import "./security/AuthorizationModule.sol";
-import "../interfaces/IRuleEngine.sol";
+import "../interfaces/IERC1404Wrapper.sol";
 
 abstract contract CMTAT_BASE is
     Initializable,
@@ -50,7 +50,7 @@ abstract contract CMTAT_BASE is
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) public initializer {
@@ -75,7 +75,7 @@ abstract contract CMTAT_BASE is
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) internal onlyInitializing {

--- a/contracts/modules/internal/ValidationModuleInternal.sol
+++ b/contracts/modules/internal/ValidationModuleInternal.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 
 import "../../../openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol";
 import "../../../openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
-import "../../interfaces/IRuleEngine.sol";
+import "../../interfaces/IERC1404Wrapper.sol";
 
 /**
  * @dev Validation module.
@@ -18,22 +18,22 @@ abstract contract ValidationModuleInternal is
     /**
      * @dev Emitted when a rule engine is set.
      */
-    event RuleEngine(IRuleEngine indexed newRuleEngine);
+    event RuleEngine(IERC1404Wrapper indexed newRuleEngine);
 
-    IRuleEngine public ruleEngine;
+    IERC1404Wrapper public ruleEngine;
 
     /**
      * @dev Initializes the contract with rule engine.
      */
     function __Validation_init(
-        IRuleEngine ruleEngine_
+        IERC1404Wrapper ruleEngine_
     ) internal onlyInitializing {
         __Context_init_unchained();
         __Validation_init_unchained(ruleEngine_);
     }
 
     function __Validation_init_unchained(
-        IRuleEngine ruleEngine_
+        IERC1404Wrapper ruleEngine_
     ) internal onlyInitializing {
         if (address(ruleEngine_) != address(0)) {
             ruleEngine = ruleEngine_;

--- a/contracts/modules/wrapper/optional/ValidationModule.sol
+++ b/contracts/modules/wrapper/optional/ValidationModule.sol
@@ -23,7 +23,7 @@ abstract contract ValidationModule is
     string constant TEXT_UNKNOWN_CODE = "Unknown code";
 
     function __ValidationModule_init(
-        IRuleEngine ruleEngine_,
+        IERC1404Wrapper ruleEngine_,
         address admin
     ) internal onlyInitializing {
         /* OpenZeppelin */
@@ -57,7 +57,7 @@ abstract contract ValidationModule is
     @param ruleEngine_ the call will be reverted if the new value of ruleEngine is the same as the current one
     */
     function setRuleEngine(
-        IRuleEngine ruleEngine_
+        IERC1404Wrapper ruleEngine_
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(ruleEngine != ruleEngine_, "Same value");
         ruleEngine = ruleEngine_;

--- a/contracts/test/killTest/CMTATKillTest.sol
+++ b/contracts/test/killTest/CMTATKillTest.sol
@@ -19,7 +19,7 @@ import "../../modules/wrapper/optional/DebtModule/DebtBaseModule.sol";
 import "../../modules/wrapper/optional/DebtModule/CreditEvents.sol";
 import "../../modules/security/AuthorizationModule.sol";
 import "../../modules/security/OnlyDelegateCallModule.sol";
-import "../../interfaces/IRuleEngine.sol";
+import "../../interfaces/IERC1404Wrapper.sol";
 
 /**
 @title A CMTAT version only for TESTING
@@ -67,7 +67,7 @@ contract CMTAT_KILL_TEST is
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) public initializer {
@@ -92,7 +92,7 @@ contract CMTAT_KILL_TEST is
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) internal onlyInitializing {

--- a/contracts/test/killTest/CMTATSnapshot/CMTATSnapshotStandaloneTest.sol
+++ b/contracts/test/killTest/CMTATSnapshot/CMTATSnapshotStandaloneTest.sol
@@ -26,7 +26,7 @@ contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) MetaTxModule(forwarderIrrevocable) {
@@ -43,6 +43,6 @@ contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest
             flag
         );
     }
-    
+
     // No storage gap because the contract is deployed in standalone mode
 }

--- a/contracts/test/killTest/CMTATSnapshot/CMTAT_BASE_SnapshotTest.sol
+++ b/contracts/test/killTest/CMTATSnapshot/CMTAT_BASE_SnapshotTest.sol
@@ -22,7 +22,7 @@ import "../../../modules/wrapper/optional/MetaTxModule.sol";
 import "../../../modules/wrapper/optional/DebtModule/DebtBaseModule.sol";
 import "../../../modules/wrapper/optional/DebtModule/CreditEvents.sol";
 import "../../../modules/security/AuthorizationModule.sol";
-import "../../../interfaces/IRuleEngine.sol";
+import "../../../interfaces/IERC1404Wrapper.sol";
 
 abstract contract CMTAT_BASE_SnapshotTest is
     Initializable,
@@ -51,7 +51,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) public initializer {
@@ -77,7 +77,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
         string memory symbolIrrevocable,
         string memory tokenId,
         string memory terms,
-        IRuleEngine ruleEngine,
+        IERC1404Wrapper ruleEngine,
         string memory information,
         uint256 flag
     ) internal onlyInitializing {


### PR DESCRIPTION
- Rename ERC1404 to EIP1404 since the proposition has never been in the finale state.
- In the CMTAT contract, the RuleEngine has to implement EIP404Wrapper instead of the RuleEngine interface in order to give more choice in the RuleEngine implementation.
- Merge CVF-7 & CVF-27