### PR TITLE
Add ERC20 decimals as an argument of the initialize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The CMTAT was developed by a working group of CMTA's Technical Committee that in
 
 The preferred way to receive comments is through the GitHub issue tracker.  Private comments and questions can be sent to the CMTA secretariat at <a href="mailto:admin@cmta.ch">admin@cmta.ch</a>. For security matters, please see [SECURITY.md](./SECURITY.MD).
 
+Note that CMTAT may be used in other jurisdictions than Switzerland, and for tokenizing various asset types, beyond equity and debt products. 
+
 ## Functionality
 
 ### Overview

--- a/contracts/CMTAT_PROXY.sol
+++ b/contracts/CMTAT_PROXY.sol
@@ -6,8 +6,8 @@ import "./modules/CMTAT_BASE.sol";
 
 contract CMTAT_PROXY is CMTAT_BASE {
     /** 
-    @notice Contract version for the deployment with a proxy
-    @param forwarderIrrevocable address of the forwarder, required for the gasless support
+    * @notice Contract version for the deployment with a proxy
+    * @param forwarderIrrevocable address of the forwarder, required for the gasless support
     */
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(

--- a/contracts/CMTAT_STANDALONE.sol
+++ b/contracts/CMTAT_STANDALONE.sol
@@ -6,16 +6,17 @@ import "./modules/CMTAT_BASE.sol";
 
 contract CMTAT_STANDALONE is CMTAT_BASE {
     /** 
-    @notice Contract version for standalone deployment
-    @param forwarderIrrevocable address of the forwarder, required for the gasless support
-    @param admin address of the admin of contract (Access Control)
-    @param nameIrrevocable name of the token
-    @param symbolIrrevocable name of the symbol
-    @param tokenId name of the tokenId
-    @param terms terms associated with the token
-    @param ruleEngine address of the ruleEngine to apply rules to transfers
-    @param information additional information to describe the token
-    @param flag add information under the form of bit(0, 1)
+    * @notice Contract version for standalone deployment
+    * @param forwarderIrrevocable address of the forwarder, required for the gasless support
+    * @param admin address of the admin of contract (Access Control)
+    * @param nameIrrevocable name of the token
+    * @param symbolIrrevocable name of the symbol
+    * @param decimalsIrrevocable number of decimals used to get its user representation, should be 0 to be compliant with the CMTAT specifications.
+    * @param tokenId_ name of the tokenId
+    * @param terms_ terms associated with the token
+    * @param ruleEngine_ address of the ruleEngine to apply rules to transfers
+    * @param information_ additional information to describe the token
+    * @param flag_ add information under the form of bit(0, 1)
     */
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
@@ -23,6 +24,7 @@ contract CMTAT_STANDALONE is CMTAT_BASE {
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
+        uint8 decimalsIrrevocable,
         string memory tokenId_,
         string memory terms_,
         IEIP1404Wrapper ruleEngine_,
@@ -35,6 +37,7 @@ contract CMTAT_STANDALONE is CMTAT_BASE {
             admin,
             nameIrrevocable,
             symbolIrrevocable,
+            decimalsIrrevocable,
             tokenId_,
             terms_,
             ruleEngine_,

--- a/contracts/modules/CMTAT_BASE.sol
+++ b/contracts/modules/CMTAT_BASE.sol
@@ -46,7 +46,7 @@ abstract contract CMTAT_BASE is
     * @param admin address of the admin of contract (Access Control)
     * @param nameIrrevocable name of the token
     * @param symbolIrrevocable name of the symbol
-    * @param decimalsIrrevocable number of decimals used to get its user representation, should be 0 to be compliant with the CMTAT specifications.
+    * @param decimalsIrrevocable number of decimals of the token, must be 0 to be compliant with Swiss law as per CMTAT specifications (non-zero decimal number may be needed for other use cases)
     * @param tokenId_ name of the tokenId
     * @param terms_ terms associated with the token
     * @param ruleEngine_ address of the ruleEngine to apply rules to transfers

--- a/contracts/modules/CMTAT_BASE.sol
+++ b/contracts/modules/CMTAT_BASE.sol
@@ -40,14 +40,24 @@ abstract contract CMTAT_BASE is
     CreditEventsModule
 {
     /**
-    @notice 
-    initialize the proxy contract
-    The calls to this function will revert if the contract was deployed without a proxy
+    * @notice 
+    * initialize the proxy contract
+    * The calls to this function will revert if the contract was deployed without a proxy
+    * @param admin address of the admin of contract (Access Control)
+    * @param nameIrrevocable name of the token
+    * @param symbolIrrevocable name of the symbol
+    * @param decimalsIrrevocable number of decimals used to get its user representation, should be 0 to be compliant with the CMTAT specifications.
+    * @param tokenId_ name of the tokenId
+    * @param terms_ terms associated with the token
+    * @param ruleEngine_ address of the ruleEngine to apply rules to transfers
+    * @param information_ additional information to describe the token
+    * @param flag_ add information under the form of bit(0, 1)
     */
     function initialize(
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
+        uint8 decimalsIrrevocable,
         string memory tokenId_,
         string memory terms_,
         IEIP1404Wrapper ruleEngine_,
@@ -58,6 +68,7 @@ abstract contract CMTAT_BASE is
             admin,
             nameIrrevocable,
             symbolIrrevocable,
+            decimalsIrrevocable,
             tokenId_,
             terms_,
             ruleEngine_,
@@ -67,12 +78,13 @@ abstract contract CMTAT_BASE is
     }
 
     /**
-    @dev calls the different initialize functions from the different modules
+    * @dev calls the different initialize functions from the different modules
     */
     function __CMTAT_init(
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
+        uint8 decimalsIrrevocable,
         string memory tokenId_,
         string memory terms_,
         IEIP1404Wrapper ruleEngine_,
@@ -105,7 +117,7 @@ abstract contract CMTAT_BASE is
         __MintModule_init_unchained();
         // EnforcementModule_init_unchained is called before ValidationModule_init_unchained due to inheritance
         __EnforcementModule_init_unchained();
-        __ERC20Module_init_unchained(0);
+        __ERC20Module_init_unchained(decimalsIrrevocable);
         // PauseModule_init_unchained is called before ValidationModule_init_unchained due to inheritance
         __PauseModule_init_unchained();
         __ValidationModule_init_unchained();
@@ -130,7 +142,7 @@ abstract contract CMTAT_BASE is
     }
 
     /**
-    @notice Returns the number of decimals used to get its user representation.
+    * @notice Returns the number of decimals used to get its user representation.
     */
     function decimals()
         public
@@ -155,12 +167,12 @@ abstract contract CMTAT_BASE is
         return ERC20BaseModule.transferFrom(sender, recipient, amount);
     }
 
-    /*
-    @dev 
-    SnapshotModule:
-    - override SnapshotModuleInternal if you add the SnapshotModule
-    e.g. override(SnapshotModuleInternal, ERC20Upgradeable)
-    - remove the keyword view
+    /** 
+    * @dev 
+    * SnapshotModule:
+    * - override SnapshotModuleInternal if you add the SnapshotModule
+    * e.g. override(SnapshotModuleInternal, ERC20Upgradeable)
+    * - remove the keyword view
     */
     function _beforeTokenTransfer(
         address from,
@@ -180,7 +192,7 @@ abstract contract CMTAT_BASE is
     }
 
     /** 
-    @dev This surcharge is not necessary if you do not use the MetaTxModule
+    * @dev This surcharge is not necessary if you do not use the MetaTxModule
     */
     function _msgSender()
         internal
@@ -192,7 +204,7 @@ abstract contract CMTAT_BASE is
     }
 
     /** 
-    @dev This surcharge is not necessary if you do not use the MetaTxModule
+    * @dev This surcharge is not necessary if you do not use the MetaTxModule
     */
     function _msgData()
         internal

--- a/contracts/test/CMTATSnapshot/CMTATSnapshotStandaloneTest.sol
+++ b/contracts/test/CMTATSnapshot/CMTATSnapshotStandaloneTest.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 import "./CMTAT_BASE_SnapshotTest.sol";
 
 contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest {
-    /** 
+ /** 
     @notice Contract version for standalone deployment
     @param forwarderIrrevocable address of the forwarder, required for the gasless support
     @param admin address of the admin of contract (Access Control)
@@ -23,11 +23,12 @@ contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest {
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IEIP1404Wrapper ruleEngine,
-        string memory information,
-        uint256 flag
+        uint8 decimalsIrrevocable,
+        string memory tokenId_,
+        string memory terms_,
+        IEIP1404Wrapper ruleEngine_,
+        string memory information_,
+        uint256 flag_
     ) MetaTxModule(forwarderIrrevocable) {
         // Initialize the contract to avoid front-running
         // Warning : do not initialize the proxy
@@ -35,11 +36,12 @@ contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest {
             admin,
             nameIrrevocable,
             symbolIrrevocable,
-            tokenId,
-            terms,
-            ruleEngine,
-            information,
-            flag
+            decimalsIrrevocable,
+            tokenId_,
+            terms_,
+            ruleEngine_,
+            information_,
+            flag_
         );
     }
 

--- a/contracts/test/CMTATSnapshot/CMTAT_BASE_SnapshotTest.sol
+++ b/contracts/test/CMTATSnapshot/CMTAT_BASE_SnapshotTest.sol
@@ -39,7 +39,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
     DebtBaseModule,
     CreditEventsModule
 {
-    /**
+/**
     @notice 
     initialize the proxy contract
     The calls to this function will revert if the contract was deployed without a proxy
@@ -48,37 +48,39 @@ abstract contract CMTAT_BASE_SnapshotTest is
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IEIP1404Wrapper ruleEngine,
-        string memory information,
-        uint256 flag
+        uint8 decimalsIrrevocable,
+        string memory tokenId_,
+        string memory terms_,
+        IEIP1404Wrapper ruleEngine_,
+        string memory information_,
+        uint256 flag_
     ) public initializer {
         __CMTAT_init(
             admin,
             nameIrrevocable,
             symbolIrrevocable,
-            tokenId,
-            terms,
-            ruleEngine,
-            information,
-            flag
+            decimalsIrrevocable,
+            tokenId_,
+            terms_,
+            ruleEngine_,
+            information_,
+            flag_
         );
     }
 
     /**
     @dev calls the different initialize functions from the different modules
-    @param admin the address has to be different from 0, check made in AuthorizationModule
     */
     function __CMTAT_init(
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IEIP1404Wrapper ruleEngine,
-        string memory information,
-        uint256 flag
+        uint8 decimalsIrrevocable,
+        string memory tokenId_,
+        string memory terms_,
+        IEIP1404Wrapper ruleEngine_,
+        string memory information_,
+        uint256 flag_
     ) internal onlyInitializing {
         /* OpenZeppelin library */
         // OZ init_unchained functions are called firstly due to inheritance
@@ -95,10 +97,9 @@ abstract contract CMTAT_BASE_SnapshotTest is
         /*
         SnapshotModule:
         Add this call in case you add the SnapshotModule
-        */
         __Snapshot_init_unchained();
-
-        __Validation_init_unchained(ruleEngine);
+        */
+        __Validation_init_unchained(ruleEngine_);
 
         /* Wrapper */
         // AuthorizationModule_init_unchained is called firstly due to inheritance
@@ -107,7 +108,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
         __MintModule_init_unchained();
         // EnforcementModule_init_unchained is called before ValidationModule_init_unchained due to inheritance
         __EnforcementModule_init_unchained();
-        __ERC20Module_init_unchained(0);
+        __ERC20Module_init_unchained(decimalsIrrevocable);
         // PauseModule_init_unchained is called before ValidationModule_init_unchained due to inheritance
         __PauseModule_init_unchained();
         __ValidationModule_init_unchained();
@@ -117,11 +118,12 @@ abstract contract CMTAT_BASE_SnapshotTest is
         Add this call in case you add the SnapshotModule
         */
         __SnasphotModule_init_unchained();
+        
 
         /* Other modules */
         __DebtBaseModule_init_unchained();
         __CreditEvents_init_unchained();
-        __Base_init_unchained(tokenId, terms, information, flag);
+        __Base_init_unchained(tokenId_, terms_, information_, flag_);
 
         /* own function */
         __CMTAT_init_unchained();

--- a/contracts/test/killTest/CMTATKillTest.sol
+++ b/contracts/test/killTest/CMTATKillTest.sol
@@ -64,21 +64,23 @@ contract CMTAT_KILL_TEST is
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IEIP1404Wrapper ruleEngine,
-        string memory information,
-        uint256 flag
+        uint8 decimalsIrrevocable,
+        string memory tokenId_,
+        string memory terms_,
+        IEIP1404Wrapper ruleEngine_,
+        string memory information_,
+        uint256 flag_
     ) public initializer {
         __CMTAT_init(
             admin,
             nameIrrevocable,
             symbolIrrevocable,
-            tokenId,
-            terms,
-            ruleEngine,
-            information,
-            flag
+            decimalsIrrevocable,
+            tokenId_,
+            terms_,
+            ruleEngine_,
+            information_,
+            flag_
         );
     }
 
@@ -89,11 +91,12 @@ contract CMTAT_KILL_TEST is
         address admin,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
-        string memory tokenId,
-        string memory terms,
-        IEIP1404Wrapper ruleEngine,
-        string memory information,
-        uint256 flag
+        uint8 decimalsIrrevocable,
+        string memory tokenId_,
+        string memory terms_,
+        IEIP1404Wrapper ruleEngine_,
+        string memory information_,
+        uint256 flag_
     ) internal onlyInitializing {
         /* OpenZeppelin library */
         // OZ init_unchained functions are called firstly due to inheritance
@@ -112,7 +115,7 @@ contract CMTAT_KILL_TEST is
         Add this call in case you add the SnapshotModule
         __Snapshot_init_unchained();
         */
-        __Validation_init_unchained(ruleEngine);
+        __Validation_init_unchained(ruleEngine_);
 
         /* Wrapper */
         // AuthorizationModule_init_unchained is called firstly due to inheritance
@@ -121,7 +124,7 @@ contract CMTAT_KILL_TEST is
         __MintModule_init_unchained();
         // EnforcementModule_init_unchained is called before ValidationModule_init_unchained due to inheritance
         __EnforcementModule_init_unchained();
-        __ERC20Module_init_unchained(0);
+        __ERC20Module_init_unchained(decimalsIrrevocable);
         // PauseModule_init_unchained is called before ValidationModule_init_unchained due to inheritance
         __PauseModule_init_unchained();
         __ValidationModule_init_unchained();
@@ -135,7 +138,7 @@ contract CMTAT_KILL_TEST is
         /* Other modules */
         __DebtBaseModule_init_unchained();
         __CreditEvents_init_unchained();
-        __Base_init_unchained(tokenId, terms, information, flag);
+        __Base_init_unchained(tokenId_, terms_, information_, flag_);
 
         /* own function */
         __CMTAT_init_unchained();

--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -14,6 +14,7 @@ module.exports = async function (deployer, _network, account) {
 			admin,
 			"Test CMTA Token",
 			"TCMTAT",
+			0,
 			"TCMTAT_ISIN",
 			"https://cmta.ch",
 			ZERO_ADDRESS,

--- a/test/deployment/deployment.test.js
+++ b/test/deployment/deployment.test.js
@@ -8,18 +8,18 @@ contract(
   function ([_], admin) {
     it('testCannotDeployProxyWithAdminSetToAddressZero', async function () {
       this.flag = 5
-
+      const DECIMAL = 0
       // Act + Assert
-      await expectRevert(deployProxy(CMTAT_PROXY, [ZERO_ADDRESS, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+      await expectRevert(deployProxy(CMTAT_PROXY, [ZERO_ADDRESS, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
         constructorArgs: [_]
       }), 'Address 0 not allowed')
     })
     it('testCannotDeployStandaloneWithAdminSetToAddressZero', async function () {
       this.flag = 5
-
+      const DECIMAL = 0
       // Act + Assert
-      await expectRevert(CMTAT_STANDALONE.new(_, ZERO_ADDRESS, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: admin }), 'Address 0 not allowed')
+      await expectRevert(CMTAT_STANDALONE.new(_, ZERO_ADDRESS, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: admin }), 'Address 0 not allowed')
     })
   }
 )

--- a/test/deploymentUtils.js
+++ b/test/deploymentUtils.js
@@ -1,0 +1,23 @@
+const { ZERO_ADDRESS } = require('./utils')
+const CMTAT_STANDALONE = artifacts.require('CMTAT_STANDALONE')
+const CMTAT_PROXY = artifacts.require('CMTAT_PROXY')
+const { deployProxy } = require('@openzeppelin/truffle-upgrades')
+const DEPLOYMENT_FLAG = 5
+const DEPLOYMENT_DECIMAL = 0
+
+async function deployCMTATStandalone (_, admin, deployerAddress) {
+  const cmtat = await CMTAT_STANDALONE.new(_, admin, 'CMTA Token', 'CMTAT', DEPLOYMENT_DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', DEPLOYMENT_FLAG, { from: deployerAddress })
+  return cmtat
+}
+
+async function deployCMTATProxy (_, admin, deployerAddress) {
+
+  const cmtat = await deployProxy(CMTAT_PROXY, [admin, 'CMTA Token', 'CMTAT', DEPLOYMENT_DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', DEPLOYMENT_FLAG], {
+    initializer: 'initialize',
+    constructorArgs: [_],
+    from: deployerAddress
+  })
+  return cmtat
+}
+
+module.exports = { deployCMTATStandalone, deployCMTATProxy, DEPLOYMENT_FLAG, DEPLOYMENT_DECIMAL }

--- a/test/proxy/general/KillImplementation.test.js
+++ b/test/proxy/general/KillImplementation.test.js
@@ -5,6 +5,7 @@
 */
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
+const DECIMAL = 0
 const { ZERO_ADDRESS } = require('../../utils')
 const {
   deployProxy,
@@ -16,9 +17,10 @@ const CMTAT_KILL_TEST = artifacts.require('CMTAT_KILL_TEST')
 contract('Proxy - Security Test', function ([_, admin]) {
   beforeEach(async function () {
     this.flag = 5
+    // Contract to deploy: CMTAT_KILL_TEST
     this.CMTAT_PROXY = await deployProxy(
       CMTAT_KILL_TEST,
-      [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag],
+      [admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag],
       {
         initializer: 'initialize',
         constructorArgs: [

--- a/test/proxy/general/Proxy.test.js
+++ b/test/proxy/general/Proxy.test.js
@@ -2,19 +2,19 @@ const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
 
 const { deployProxy, upgradeProxy, erc1967 } = require('@openzeppelin/truffle-upgrades')
-const CMTAT1 = artifacts.require('CMTAT_PROXY')
-const { DEFAULT_ADMIN_ROLE } = require('../../utils')
 const CMTAT = artifacts.require('CMTAT_PROXY')
+const { DEFAULT_ADMIN_ROLE } = require('../../utils')
 const { ZERO_ADDRESS } = require('../../utils')
+const DECIMAL = 0
+const { deployCMTATProxy, DEPLOYMENT_FLAG } = require('../../deploymentUtils')
+
 contract(
   'Proxy - Security Test',
-  function ([_, admin, attacker]) {
+  function ([_, admin, attacker, deployerAddress]) {
     beforeEach(async function () {
       this.flag = 5
-      this.CMTAT_PROXY = await deployProxy(CMTAT1, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+         // Contract to deploy: CMTAT
+      this.CMTAT_PROXY = await deployCMTATProxy(_, admin, deployerAddress)
       const implementationContractAddress = await erc1967.getImplementationAddress(this.CMTAT_PROXY.address, { from: admin })
       this.implementationContract = await CMTAT.at(implementationContractAddress)
     })
@@ -23,7 +23,7 @@ contract(
       // Here the argument to indicate if it is deployed with a proxy, set at false by the attacker
       it('testCannotBeTakenControlByAttacker1', async function () {
         await expectRevert(
-          this.implementationContract.initialize(attacker, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: attacker }),
+          this.implementationContract.initialize(attacker, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', DEPLOYMENT_FLAG, { from: attacker }),
           'Initializable: contract is already initialized'
         )
         await expectRevert(
@@ -37,7 +37,7 @@ contract(
       // Here the argument to indicate if it is deployed with a proxy, set at true by the attacker
       it('testCannotBeTakenControlByAttacker2', async function () {
         await expectRevert(
-          this.implementationContract.initialize(attacker, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: attacker }),
+          this.implementationContract.initialize(attacker, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', DEPLOYMENT_FLAG, { from: attacker }),
           'Initializable: contract is already initialized'
         )
         await expectRevert(

--- a/test/proxy/general/UpgradeProxy.test.js
+++ b/test/proxy/general/UpgradeProxy.test.js
@@ -5,6 +5,7 @@ const { deployProxy, upgradeProxy, erc1967 } = require('@openzeppelin/truffle-up
 const CMTAT1 = artifacts.require('CMTAT_PROXY')
 const CMTAT2 = artifacts.require('CMTAT_PROXY')
 const { ZERO_ADDRESS } = require('../../utils')
+const DECIMAL = 0
 
 contract('UpgradeableCMTAT - Proxy', function ([_, admin, address1]) {
   /*
@@ -13,7 +14,7 @@ contract('UpgradeableCMTAT - Proxy', function ([_, admin, address1]) {
   it('testKeepStorageForTokens', async function () {
     this.flag = 5
     // With the first version of CMTAT
-    this.CMTAT_PROXY = await deployProxy(CMTAT1, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+    this.CMTAT_PROXY = await deployProxy(CMTAT1, [admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
       initializer: 'initialize',
       constructorArgs: [_]
     })

--- a/test/proxy/modules/AuthorizationModule/AuthorizationModule.test.js
+++ b/test/proxy/modules/AuthorizationModule/AuthorizationModule.test.js
@@ -1,19 +1,13 @@
-const CMTAT = artifacts.require('CMTAT_PROXY')
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const AuthorizationModuleCommon = require('../../../common/AuthorizationModule/AuthorizationModuleCommon')
-const { ZERO_ADDRESS } = require('../../../utils')
+const {deployCMTATProxy} = require('../../../deploymentUtils')
 
 contract(
   'Proxy - AuthorizationModule',
-  function ([_, owner, address1, address2]) {
+  function ([_, admin, address1, address2, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [owner, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
-    AuthorizationModuleCommon(owner, address1, address2)
+    AuthorizationModuleCommon(admin, address1, address2)
   }
 )

--- a/test/proxy/modules/BaseModule.test.js
+++ b/test/proxy/modules/BaseModule.test.js
@@ -2,16 +2,14 @@ const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const CMTAT = artifacts.require('CMTAT_PROXY')
 const BaseModuleCommon = require('../../common/BaseModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy, DEPLOYMENT_FLAG} = require('../../deploymentUtils')
 
 contract(
   'Proxy - BaseModule',
-  function ([_, admin, address1, address2, address3]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.flag = DEPLOYMENT_FLAG // value used in tests
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     BaseModuleCommon(admin, address1, address2, address3, true)

--- a/test/proxy/modules/BurnModule.test.js
+++ b/test/proxy/modules/BurnModule.test.js
@@ -1,17 +1,11 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT_PROXY')
 const BurnModuleCommon = require('../../common/BurnModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
 contract(
   'Proxy - BurnModule',
-  function ([_, admin, address1, address2]) {
+  function ([_, admin, address1, address2, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     BurnModuleCommon(admin, address1, address2)

--- a/test/proxy/modules/CreditEventsModule.test.js
+++ b/test/proxy/modules/CreditEventsModule.test.js
@@ -1,17 +1,11 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT_PROXY')
 const CreditEventsModuleCommon = require('../../common/CreditEventsModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
 contract(
   'Proxy - CreditEventsModule',
-  function ([_, admin, attacker]) {
+  function ([_, admin, attacker, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     CreditEventsModuleCommon(admin, attacker)

--- a/test/proxy/modules/DebtModule.test.js
+++ b/test/proxy/modules/DebtModule.test.js
@@ -1,17 +1,11 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT_PROXY')
 const DebtModuleCommon = require('../../common/DebtModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
 contract(
   'Proxy - DebtModule',
-  function ([_, admin, address1, address2, address3]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     DebtModuleCommon(admin, address1, address2, address3, true)

--- a/test/proxy/modules/ERC20BaseModule.test.js
+++ b/test/proxy/modules/ERC20BaseModule.test.js
@@ -1,17 +1,11 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT_PROXY')
-const ERC20BaseModuleCommon = require('../../common/BaseModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const ERC20BaseModuleCommon = require('../../common/ERC20BaseModuleCommon')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
 contract(
   'Proxy - ERC20BaseModule',
-  function ([_, admin, address1, address2, address3]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     ERC20BaseModuleCommon(admin, address1, address2, address3, true)

--- a/test/proxy/modules/EnforcementModule.test.js
+++ b/test/proxy/modules/EnforcementModule.test.js
@@ -1,17 +1,11 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT_PROXY')
 const EnforcementModuleCommon = require('../../common/EnforcementModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
 contract(
   'Proxy - EnforcementModule',
-  function ([_, admin, address1, address2, address3]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     EnforcementModuleCommon(admin, address1, address2, address3)

--- a/test/proxy/modules/MetaTxModule.test.js
+++ b/test/proxy/modules/MetaTxModule.test.js
@@ -13,9 +13,10 @@ contract(
   ]) {
     beforeEach(async function () {
       this.flag = 5
+      const DECIMAL = 0
       this.trustedForwarder = await MinimalForwarderMock.new()
       await this.trustedForwarder.initialize()
-      this.cmtat = await deployProxy(CMTAT, [owner, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+      this.cmtat = await deployProxy(CMTAT, [owner, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
         constructorArgs: [this.trustedForwarder.address]
       })

--- a/test/proxy/modules/MintModule.test.js
+++ b/test/proxy/modules/MintModule.test.js
@@ -1,17 +1,13 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const CMTAT = artifacts.require('CMTAT_PROXY')
 const MintModuleCommon = require('../../common/MintModuleCommon')
 const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
 contract(
   'Proxy - MintModule',
-  function ([_, admin, address1, address2]) {
+  function ([_, admin, address1, address2, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-        initializer: 'initialize',
-        constructorArgs: [_]
-      })
+      this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     })
 
     MintModuleCommon(admin, address1, address2)

--- a/test/proxy/modules/PauseModule.test.js
+++ b/test/proxy/modules/PauseModule.test.js
@@ -1,15 +1,9 @@
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
-const CMTAT = artifacts.require('CMTAT_PROXY')
 const PauseModuleCommon = require('../../common/PauseModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATProxy} = require('../../deploymentUtils')
 
-contract('Proxy - PauseModule', function ([_, admin, address1, address2, address3]) {
+contract('Proxy - PauseModule', function ([_, admin, address1, address2, address3, deployerAddress]) {
   beforeEach(async function () {
-    this.flag = 5
-    this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
-      initializer: 'initialize',
-      constructorArgs: [_]
-    })
+    this.cmtat = await deployCMTATProxy(_, admin, deployerAddress)
     // Mint tokens to test the transfer
     await this.cmtat.mint(address1, 20, {
       from: admin

--- a/test/proxy/modules/SnapshotModule.test.js
+++ b/test/proxy/modules/SnapshotModule.test.js
@@ -9,13 +9,14 @@ const SnapshotModuleMultiplePlannedTest = require('../../common/SnapshotModuleCo
 const SnapshotModuleOnePlannedSnapshotTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleOnePlannedSnapshotTest')
 const SnapshotModuleZeroPlannedSnapshotTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleZeroPlannedSnapshot')
 const { ZERO_ADDRESS } = require('../../utils')
+const DECIMAL = 0
 
 contract(
   'Proxy - SnapshotModule',
   function ([_, admin, address1, address2, address3]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
         constructorArgs: [_]
       })

--- a/test/proxy/modules/ValidationModule/ValidationModule.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModule.test.js
@@ -11,8 +11,9 @@ contract(
   function ([_, admin, address1, address2, address3]) {
     beforeEach(async function () {
       this.flag = 5
+      const DECIMAL = 0
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
         constructorArgs: [_]
       })

--- a/test/proxy/modules/ValidationModule/ValidationModuleConstructor.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModuleConstructor.test.js
@@ -10,8 +10,9 @@ contract(
   function ([_, admin, address1, address2, address3]) {
     beforeEach(async function () {
       this.flag = 5
+      const DECIMAL = 0
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag], {
+      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
         constructorArgs: [_]
       })

--- a/test/proxy/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
@@ -7,7 +7,8 @@ contract(
   function ([_, admin, address1, fakeRuleEngine]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
+      const DECIMAL = 0
+      this.cmtat = await deployProxy(CMTAT, [admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag], {
         initializer: 'initialize',
         constructorArgs: [_]
       })

--- a/test/standard/modules/AuthorizationModule/AuthorizationModule.test.js
+++ b/test/standard/modules/AuthorizationModule/AuthorizationModule.test.js
@@ -1,13 +1,11 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const AuthorizationModuleCommon = require('../../../common/AuthorizationModule/AuthorizationModuleCommon')
-const { ZERO_ADDRESS } = require('../../../utils')
+const {deployCMTATStandalone} = require('../../../deploymentUtils')
 
 contract(
   'Standard - AuthorizationModule',
-  function ([_, admin, address1, address2, randomDeployer]) {
+  function ([_, admin, address1, address2, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     AuthorizationModuleCommon(admin, address1, address2)

--- a/test/standard/modules/BaseModule.test.js
+++ b/test/standard/modules/BaseModule.test.js
@@ -1,13 +1,11 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const BaseModuleCommon = require('../../common/BaseModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const {deployCMTATStandalone, DEPLOYMENT_FLAG} = require('../../deploymentUtils')
 contract(
   'Standard - BaseModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.flag = DEPLOYMENT_FLAG // value used in tests
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     BaseModuleCommon(admin, address1, address2, address3, false)

--- a/test/standard/modules/BurnModule.test.js
+++ b/test/standard/modules/BurnModule.test.js
@@ -1,13 +1,10 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const BurnModuleCommon = require('../../common/BurnModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const {deployCMTATStandalone} = require('../../deploymentUtils')
 contract(
   'Standard - BurnModule',
-  function ([_, admin, address1, address2, randomDeployer]) {
+  function ([_, admin, address1, address2, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     BurnModuleCommon(admin, address1, address2)

--- a/test/standard/modules/CreditEventsModule.test.js
+++ b/test/standard/modules/CreditEventsModule.test.js
@@ -1,13 +1,10 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const CreditEventsModuleCommon = require('../../common/CreditEventsModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const {deployCMTATStandalone} = require('../../deploymentUtils')
 contract(
   'Standard - CreditEventsModule',
-  function ([_, admin, attacker, randomDeployer]) {
+  function ([_, admin, attacker, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     CreditEventsModuleCommon(admin, attacker)

--- a/test/standard/modules/DebtModule.test.js
+++ b/test/standard/modules/DebtModule.test.js
@@ -1,13 +1,10 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const DebtModuleCommon = require('../../common/DebtModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const {deployCMTATStandalone} = require('../../deploymentUtils')
 contract(
   'Standard - DebtModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     DebtModuleCommon(admin, address1, address2, address3, false)

--- a/test/standard/modules/ERC20BaseModule.test.js
+++ b/test/standard/modules/ERC20BaseModule.test.js
@@ -1,13 +1,10 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const ERC20BaseModuleCommon = require('../../common/ERC20BaseModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const {deployCMTATStandalone} = require('../../deploymentUtils')
 contract(
   'Standard - ERC20BaseModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     ERC20BaseModuleCommon(admin, address1, address2, address3, false)

--- a/test/standard/modules/EnforcementModule.test.js
+++ b/test/standard/modules/EnforcementModule.test.js
@@ -1,14 +1,10 @@
-
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const EnforcementModuleCommon = require('../../common/EnforcementModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const {deployCMTATStandalone} = require('../../deploymentUtils')
 contract(
   'Standard - EnforcementModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     EnforcementModuleCommon(admin, address1, address2, address3)

--- a/test/standard/modules/MetaTxModule.test.js
+++ b/test/standard/modules/MetaTxModule.test.js
@@ -13,9 +13,10 @@ contract(
   ]) {
     beforeEach(async function () {
       this.flag = 5
+      const DECIMAL = 0
       this.trustedForwarder = await MinimalForwarderMock.new()
       this.trustedForwarder.initialize()
-      this.cmtat = await CMTAT.new(this.trustedForwarder.address, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(this.trustedForwarder.address, admin, 'CMTA Token', 'CMTAT',  DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
 
     MetaTxModuleCommon(admin, address1)

--- a/test/standard/modules/MintModule.test.js
+++ b/test/standard/modules/MintModule.test.js
@@ -1,13 +1,10 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const MintModuleCommon = require('../../common/MintModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
-
+const { deployCMTATStandalone } = require('../../deploymentUtils')
 contract(
   'Standard - MintModule',
-  function ([_, admin, address1, address2, randomDeployer]) {
+  function ([_, admin, address1, address2, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
     })
 
     MintModuleCommon(admin, address1, address2)

--- a/test/standard/modules/PauseModule.test.js
+++ b/test/standard/modules/PauseModule.test.js
@@ -1,12 +1,10 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
 const PauseModuleCommon = require('../../common/PauseModuleCommon')
-const { ZERO_ADDRESS } = require('../../utils')
+const {deployCMTATStandalone} = require('../../deploymentUtils')
 contract(
   'Standard - PauseModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await deployCMTATStandalone(_, admin, deployerAddress)
       // Mint tokens to test the transfer
       await this.cmtat.mint(address1, 20, {
         from: admin

--- a/test/standard/modules/SnapshotModule.test.js
+++ b/test/standard/modules/SnapshotModule.test.js
@@ -8,12 +8,13 @@ const SnapshotModuleMultiplePlannedTest = require('../../common/SnapshotModuleCo
 const SnapshotModuleOnePlannedSnapshotTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleOnePlannedSnapshotTest')
 const SnapshotModuleZeroPlannedSnapshotTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleZeroPlannedSnapshot')
 const { ZERO_ADDRESS } = require('../../utils')
+const DECIMAL = 0
 contract(
   'Standard - SnapshotModule',
   function ([_, admin, address1, address2, address3, randomDeployer]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
     })
     SnapshotModuleMultiplePlannedTest(admin, address1, address2, address3)
     SnapshotModuleOnePlannedSnapshotTest(admin, address1, address2, address3)

--- a/test/standard/modules/ValidationModule/ValidationModule.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModule.test.js
@@ -6,10 +6,11 @@ const ADDRESS2_INITIAL_BALANCE = 32
 const ADDRESS3_INITIAL_BALANCE = 33
 contract(
   'Standard - ValidationModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      const DECIMAL = 0
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: deployerAddress })
       await this.cmtat.mint(address1, ADDRESS1_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address2, ADDRESS2_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address3, ADDRESS3_INITIAL_BALANCE, { from: admin })

--- a/test/standard/modules/ValidationModule/ValidationModuleConstructor.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModuleConstructor.test.js
@@ -6,11 +6,12 @@ const ADDRESS2_INITIAL_BALANCE = 18
 const ADDRESS3_INITIAL_BALANCE = 19
 contract(
   'Standard - ValidationModule - Constructor',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
       this.flag = 5
+      const DECIMAL = 0
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag, { from: randomDeployer })
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', this.ruleEngineMock.address, 'CMTAT_info', this.flag, { from: deployerAddress })
       await this.cmtat.mint(address1, ADDRESS1_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address2, ADDRESS2_INITIAL_BALANCE, { from: admin })
       await this.cmtat.mint(address3, ADDRESS3_INITIAL_BALANCE, { from: admin })

--- a/test/standard/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModuleSetRuleEngine.test.js
@@ -3,10 +3,11 @@ const ValidationModuleSetRuleEngineCommon = require('../../../common/ValidationM
 const { ZERO_ADDRESS } = require('../../../utils')
 contract(
   'Standard - ValidationModule - setRuleEngine',
-  function ([_, admin, address1, fakeRuleEngine, randomDeployer]) {
+  function ([_, admin, address1, fakeRuleEngine, deployerAddress]) {
     beforeEach(async function () {
       this.flag = 5
-      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: randomDeployer })
+      const DECIMAL = 5
+      this.cmtat = await CMTAT.new(_, admin, 'CMTA Token', 'CMTAT', DECIMAL, 'CMTAT_ISIN', 'https://cmta.ch', ZERO_ADDRESS, 'CMTAT_info', this.flag, { from: deployerAddress })
     })
     ValidationModuleSetRuleEngineCommon(admin, address1, fakeRuleEngine)
   }


### PR DESCRIPTION
closes #212 
- [x] Add `decimals` as an argument of the initialize function
- [x] Refactor the tests to centralize CMTAT deployment

The CMTAT should be the most possible generic to allow a maximum of use case.

Until now, the number of decimal was set inside the code to the value `0`

This PR changes this behavior to use instead a parameter supplied by the deployer inside the function initialize.

This PR refactors also the tests by adding a file `DeploymentUtils` which provide a function to deploy the CMTAT in order to centralize the deployment between the different tests.

