### PR TITLE
Add AccessControlDefaultAdminRules

### DIFF
--- a/contracts/CMTAT_STANDALONE.sol
+++ b/contracts/CMTAT_STANDALONE.sol
@@ -22,6 +22,7 @@ contract CMTAT_STANDALONE is CMTAT_BASE {
     constructor(
         address forwarderIrrevocable,
         address admin,
+        uint48 initialDelay, 
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -35,6 +36,7 @@ contract CMTAT_STANDALONE is CMTAT_BASE {
         // Warning : do not initialize the proxy
         initialize(
             admin,
+            initialDelay,
             nameIrrevocable,
             symbolIrrevocable,
             decimalsIrrevocable,

--- a/contracts/modules/CMTAT_BASE.sol
+++ b/contracts/modules/CMTAT_BASE.sol
@@ -57,6 +57,7 @@ abstract contract CMTAT_BASE is
      */
     function initialize(
         address admin,
+        uint48 initialDelayToAcceptAdminRole, 
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -68,6 +69,7 @@ abstract contract CMTAT_BASE is
     ) public initializer {
         __CMTAT_init(
             admin,
+            initialDelayToAcceptAdminRole, 
             nameIrrevocable,
             symbolIrrevocable,
             decimalsIrrevocable,
@@ -84,6 +86,7 @@ abstract contract CMTAT_BASE is
      */
     function __CMTAT_init(
         address admin,
+        uint48 initialDelayToAcceptAdminRole, 
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -101,6 +104,7 @@ abstract contract CMTAT_BASE is
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         __Pausable_init_unchained();
 
         /* Internal Modules */
@@ -114,7 +118,7 @@ abstract contract CMTAT_BASE is
 
         /* Wrapper */
         // AuthorizationModule_init_unchained is called firstly due to inheritance
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
         __BurnModule_init_unchained();
         __MintModule_init_unchained();
         // EnforcementModule_init_unchained is called before ValidationModule_init_unchained due to inheritance

--- a/contracts/modules/wrapper/mandatory/BaseModule.sol
+++ b/contracts/modules/wrapper/mandatory/BaseModule.sol
@@ -39,7 +39,8 @@ abstract contract BaseModule is AuthorizationModule, OnlyDelegateCallModule {
         string memory terms_,
         string memory information_,
         uint256 flag_,
-        address admin
+        address admin,
+        uint48 initialDelayToAcceptAdminRole
     ) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
@@ -47,11 +48,10 @@ abstract contract BaseModule is AuthorizationModule, OnlyDelegateCallModule {
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Security
-        __AuthorizationModule_init_unchained(admin);
-
+        __AuthorizationModule_init_unchained();
         // own function
         __Base_init_unchained(tokenId_, terms_, information_, flag_);
     }

--- a/contracts/modules/wrapper/mandatory/BurnModule.sol
+++ b/contracts/modules/wrapper/mandatory/BurnModule.sol
@@ -15,7 +15,8 @@ abstract contract BurnModule is ERC20Upgradeable, AuthorizationModule {
     function __BurnModule_init(
         string memory name_,
         string memory symbol_,
-        address admin
+        address admin,
+        uint48 initialDelayToAcceptAdminRole
     ) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
@@ -24,10 +25,10 @@ abstract contract BurnModule is ERC20Upgradeable, AuthorizationModule {
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained( initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __BurnModule_init_unchained();

--- a/contracts/modules/wrapper/mandatory/EnforcementModule.sol
+++ b/contracts/modules/wrapper/mandatory/EnforcementModule.sol
@@ -22,20 +22,20 @@ abstract contract EnforcementModule is
     string internal constant TEXT_TRANSFER_REJECTED_TO_FROZEN =
         "The address TO is frozen";
 
-    function __EnforcementModule_init(address admin) internal onlyInitializing {
+    function __EnforcementModule_init(address admin, uint48 initialDelayToAcceptAdminRole) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
         // AccessControlUpgradeable inherits from ERC165Upgradeable
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Internal
         __Enforcement_init_unchained();
 
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __EnforcementModule_init_unchained();

--- a/contracts/modules/wrapper/mandatory/MintModule.sol
+++ b/contracts/modules/wrapper/mandatory/MintModule.sol
@@ -16,7 +16,8 @@ abstract contract MintModule is ERC20Upgradeable, AuthorizationModule {
     function __MintModule_init(
         string memory name_,
         string memory symbol_,
-        address admin
+        address admin,
+        uint48 initialDelayToAcceptAdminRole
     ) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
@@ -25,10 +26,10 @@ abstract contract MintModule is ERC20Upgradeable, AuthorizationModule {
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __MintModule_init_unchained();

--- a/contracts/modules/wrapper/mandatory/PauseModule.sol
+++ b/contracts/modules/wrapper/mandatory/PauseModule.sol
@@ -17,7 +17,7 @@ abstract contract PauseModule is PausableUpgradeable, AuthorizationModule {
     string internal constant TEXT_TRANSFER_REJECTED_PAUSED =
         "All transfers paused";
 
-    function __PauseModule_init(address admin) internal onlyInitializing {
+    function __PauseModule_init(address admin, uint48 initialDelayToAcceptAdminRole) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
         __Pausable_init_unchained();
@@ -25,10 +25,10 @@ abstract contract PauseModule is PausableUpgradeable, AuthorizationModule {
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __PauseModule_init_unchained();

--- a/contracts/modules/wrapper/optional/DebtModule/CreditEventsModule.sol
+++ b/contracts/modules/wrapper/optional/DebtModule/CreditEventsModule.sol
@@ -22,7 +22,9 @@ abstract contract CreditEventsModule is
     event FlagRedeemed(bool indexed newFlagRedeemed);
     event Rating(string indexed newRatingIndexed, string newRating);
 
-    function __CreditEvents_init(address admin) internal onlyInitializing {
+    function __CreditEvents_init(
+        address admin,
+        uint48 initialDelayToAcceptAdminRole) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
 
@@ -30,10 +32,10 @@ abstract contract CreditEventsModule is
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __CreditEvents_init_unchained();

--- a/contracts/modules/wrapper/optional/DebtModule/DebtBaseModule.sol
+++ b/contracts/modules/wrapper/optional/DebtModule/DebtBaseModule.sol
@@ -55,7 +55,9 @@ abstract contract DebtBaseModule is
         string newCouponFrequency
     );
 
-    function __DebtBaseModule_init(address admin) internal onlyInitializing {
+    function __DebtBaseModule_init(
+        address admin,
+        uint48 initialDelayToAcceptAdminRole) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
 
@@ -63,10 +65,10 @@ abstract contract DebtBaseModule is
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __DebtBaseModule_init_unchained();

--- a/contracts/modules/wrapper/optional/SnapshotModule.sol
+++ b/contracts/modules/wrapper/optional/SnapshotModule.sol
@@ -19,7 +19,8 @@ abstract contract SnapshotModule is
     function __SnasphotModule_init(
         string memory name_,
         string memory symbol_,
-        address admin
+        address admin,
+        uint48 initialDelayToAcceptAdminRole
     ) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
@@ -29,13 +30,13 @@ abstract contract SnapshotModule is
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
-
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         /* CMTAT modules */
         // Internal
         __Snapshot_init_unchained();
 
         // Security
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
 
         // own function
         __SnasphotModule_init_unchained();

--- a/contracts/modules/wrapper/optional/ValidationModule.sol
+++ b/contracts/modules/wrapper/optional/ValidationModule.sol
@@ -26,13 +26,16 @@ abstract contract ValidationModule is
 
     function __ValidationModule_init(
         IEIP1404Wrapper ruleEngine_,
-        address admin
+        address admin,
+        uint48 initialDelayToAcceptAdminRole
     ) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
         // AccessControlUpgradeable inherits from ERC165Upgradeable
         __ERC165_init_unchained();
         __AccessControl_init_unchained();
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
+
         __Pausable_init_unchained();
 
         /* CMTAT modules */
@@ -40,8 +43,8 @@ abstract contract ValidationModule is
         __Validation_init_unchained(ruleEngine_);
 
         // Security
-        __AuthorizationModule_init_unchained(admin);
-
+        __AuthorizationModule_init_unchained();
+  
         // Wrapper
         __PauseModule_init_unchained();
         __EnforcementModule_init_unchained();

--- a/contracts/test/CMTATSnapshot/CMTATSnapshotStandaloneTest.sol
+++ b/contracts/test/CMTATSnapshot/CMTATSnapshotStandaloneTest.sol
@@ -21,6 +21,7 @@ contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest {
     constructor(
         address forwarderIrrevocable,
         address admin,
+        uint48 initialDelayToAcceptAdminRole,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -34,6 +35,7 @@ contract CMTATSnapshotStandaloneTest is CMTAT_BASE_SnapshotTest {
         // Warning : do not initialize the proxy
         initialize(
             admin,
+            initialDelayToAcceptAdminRole,
             nameIrrevocable,
             symbolIrrevocable,
             decimalsIrrevocable,

--- a/contracts/test/CMTATSnapshot/CMTAT_BASE_SnapshotTest.sol
+++ b/contracts/test/CMTATSnapshot/CMTAT_BASE_SnapshotTest.sol
@@ -48,6 +48,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
     */
     function initialize(
         address admin,
+        uint48 initialDelayToAcceptAdminRole, 
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -59,6 +60,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
     ) public initializer {
         __CMTAT_init(
             admin,
+            initialDelayToAcceptAdminRole,
             nameIrrevocable,
             symbolIrrevocable,
             decimalsIrrevocable,
@@ -75,6 +77,7 @@ abstract contract CMTAT_BASE_SnapshotTest is
     */
     function __CMTAT_init(
         address admin,
+        uint48 initialDelayToAcceptAdminRole, 
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -99,13 +102,15 @@ abstract contract CMTAT_BASE_SnapshotTest is
         /*
         SnapshotModule:
         Add this call in case you add the SnapshotModule
-        __Snapshot_init_unchained();
         */
+        __Snapshot_init_unchained();
+        
         __Validation_init_unchained(ruleEngine_);
 
         /* Wrapper */
         // AuthorizationModule_init_unchained is called firstly due to inheritance
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         __BurnModule_init_unchained();
         __MintModule_init_unchained();
         // EnforcementModule_init_unchained is called before ValidationModule_init_unchained due to inheritance

--- a/contracts/test/killTest/BaseModuleTest.sol
+++ b/contracts/test/killTest/BaseModuleTest.sol
@@ -49,8 +49,7 @@ abstract contract BaseModuleTest is
         string memory tokenId_,
         string memory terms_,
         string memory information_,
-        uint256 flag_,
-        address admin
+        uint256 flag_
     ) internal onlyInitializing {
         /* OpenZeppelin */
         __Context_init_unchained();
@@ -60,7 +59,8 @@ abstract contract BaseModuleTest is
         __AccessControl_init_unchained();
 
         /* Wrapper */
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
+
 
         /* own function */
         __Base_init_unchained(tokenId_, terms_, information_, flag_);

--- a/contracts/test/killTest/CMTATKillTest.sol
+++ b/contracts/test/killTest/CMTATKillTest.sol
@@ -64,6 +64,7 @@ contract CMTAT_KILL_TEST is
     */
     function initialize(
         address admin,
+        uint48 initialDelayToAcceptAdminRole, 
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -75,6 +76,7 @@ contract CMTAT_KILL_TEST is
     ) public initializer {
         __CMTAT_init(
             admin,
+            initialDelayToAcceptAdminRole,
             nameIrrevocable,
             symbolIrrevocable,
             decimalsIrrevocable,
@@ -91,6 +93,7 @@ contract CMTAT_KILL_TEST is
     */
     function __CMTAT_init(
         address admin,
+        uint48 initialDelayToAcceptAdminRole,
         string memory nameIrrevocable,
         string memory symbolIrrevocable,
         uint8 decimalsIrrevocable,
@@ -108,6 +111,7 @@ contract CMTAT_KILL_TEST is
         __ERC165_init_unchained();
         // AuthorizationModule inherits from AccessControlUpgradeable
         __AccessControl_init_unchained();
+        __AccessControlDefaultAdminRules_init_unchained(initialDelayToAcceptAdminRole, admin);
         __Pausable_init_unchained();
 
         /* Internal Modules */
@@ -121,7 +125,7 @@ contract CMTAT_KILL_TEST is
 
         /* Wrapper */
         // AuthorizationModule_init_unchained is called firstly due to inheritance
-        __AuthorizationModule_init_unchained(admin);
+        __AuthorizationModule_init_unchained();
         __BurnModule_init_unchained();
         __MintModule_init_unchained();
         // EnforcementModule_init_unchained is called before ValidationModule_init_unchained due to inheritance

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,7 @@ require('@openzeppelin/hardhat-upgrades')
 require("hardhat-gas-reporter");
 require("solidity-coverage")
 require('solidity-docgen')
+require("hardhat-contract-sizer");
 module.exports = {
   solidity: {
     version: '0.8.20',
@@ -17,5 +18,12 @@ module.exports = {
       },
       viaIR: false
     }
+  },
+  contractSizer: {
+    alphaSort: true,
+    disambiguatePaths: false,
+    runOnCompile: true,
+    strict: true,
+    //only: [':ERC20$'],
   }
 }

--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -3,29 +3,31 @@ require('dotenv').config()
 const CMTAT_PROXY = artifacts.require("CMTAT_PROXY")
 const { deployProxy } = require("@openzeppelin/truffle-upgrades")
 const { Address } = require("ethereumjs-util")
-
+const { time } = require('@openzeppelin/test-helpers')
 module.exports = async function (deployer, _network, account) {
-	const admin = process.env.ADMIN_ADDRESS ? process.env.ADMIN_ADDRESS : account[0]
-	const flag = 0
-	const ZERO_ADDRESS = Address.zero().toString()
-	const proxyContract = await deployProxy(
-		CMTAT_PROXY,
-		[
-			admin,
-			"Test CMTA Token",
-			"TCMTAT",
-			0,
-			"TCMTAT_ISIN",
-			"https://cmta.ch",
-			ZERO_ADDRESS,
-			"TCMTAT_info",
-			flag,
-		],
-		{
-			deployer,
-			constructorArgs: [ZERO_ADDRESS]
-		}
-	);
-	await CMTAT_PROXY.deployed()
-	console.log("Proxy deployed at: ", proxyContract.address)
+  const admin = process.env.ADMIN_ADDRESS ? process.env.ADMIN_ADDRESS : account[0]
+  const flag = 0
+  const ZERO_ADDRESS = Address.zero().toString()
+  const delayTime = BigInt(time.duration.days(3))
+  const proxyContract = await deployProxy(
+    CMTAT_PROXY,
+    [
+      admin,
+	  delayTime,
+      "Test CMTA Token",
+      "TCMTAT",
+      0,
+      "TCMTAT_ISIN",
+      "https://cmta.ch",
+      ZERO_ADDRESS,
+      "TCMTAT_info",
+      flag,
+    ],
+    {
+      deployer,
+      constructorArgs: [ZERO_ADDRESS]
+    }
+  );
+  await CMTAT_PROXY.deployed()
+  console.log("Proxy deployed at: ", proxyContract.address)
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   "homepage": "https://github.com/CMTA/CMTAT",
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
-    "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
     "@nomiclabs/hardhat-truffle5": "^2.0.7",
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@openzeppelin/hardhat-upgrades": "^2.1.1",

--- a/test/common/MetaTxModuleCommon.js
+++ b/test/common/MetaTxModuleCommon.js
@@ -7,17 +7,8 @@ const {
 // const ethSigUtil = require('@metamask/eth-sig-util')
 const ethSigUtil = require('eth-sig-util')
 const Wallet = require('ethereumjs-wallet').default
-const { ERC2771ForwarderDomain } = require('../utils')
 const { should } = require('chai').should()
 const { expect } = require('chai')
-const VERSION = '0.0.1'
-const EIP712Domain = [
-  { name: 'name', type: 'string' },
-  { name: 'version', type: 'string' },
-  { name: 'chainId', type: 'uint256' },
-  { name: 'verifyingContract', type: 'address' },
-  { name: 'salt', type: 'bytes32' }
-]
 
 function MetaTxModuleCommon (owner, address1) {
   context('Transferring without paying gas', function () {

--- a/test/deployment/deployment.test.js
+++ b/test/deployment/deployment.test.js
@@ -1,21 +1,24 @@
 const {
   expectRevertCustomError
 } = require('../../openzeppelin-contracts-upgradeable/test/helpers/customError.js')
+const { time } = require('@openzeppelin/test-helpers')
 const { ZERO_ADDRESS } = require('../utils')
 const {
   deployCMTATProxyWithParameter,
   deployCMTATStandaloneWithParameter
 } = require('../deploymentUtils')
-contract('CMTAT - Deployment', function ([_], admin) {
+contract('CMTAT - Deployment', function ([_], deployer) {
   it('testCannotDeployProxyWithAdminSetToAddressZero', async function () {
+    const delayTime = BigInt(time.duration.days(3))
     this.flag = 5
     const DECIMAL = 0
     // Act + Assert
     await expectRevertCustomError(
       deployCMTATProxyWithParameter(
-        admin,
+        deployer,
         _,
         ZERO_ADDRESS,
+        delayTime,
         'CMTA Token',
         'CMTAT',
         DECIMAL,
@@ -25,8 +28,8 @@ contract('CMTAT - Deployment', function ([_], admin) {
         'CMTAT_info',
         this.flag
       ),
-      'CMTAT_AuthorizationModule_AddressZeroNotAllowed',
-      []
+      'AccessControlInvalidDefaultAdmin',
+      [ZERO_ADDRESS]
     )
   })
   it('testCannotDeployStandaloneWithAdminSetToAddressZero', async function () {
@@ -35,9 +38,10 @@ contract('CMTAT - Deployment', function ([_], admin) {
     // Act + Assert
     await expectRevertCustomError(
       deployCMTATStandaloneWithParameter(
-        admin,
+        deployer,
         _,
         ZERO_ADDRESS,
+        web3.utils.toBN(time.duration.days(3)),
         'CMTA Token',
         'CMTAT',
         DECIMAL,
@@ -47,8 +51,8 @@ contract('CMTAT - Deployment', function ([_], admin) {
         'CMTAT_info',
         this.flag
       ),
-      'CMTAT_AuthorizationModule_AddressZeroNotAllowed',
-      []
+      'AccessControlInvalidDefaultAdmin',
+      [ZERO_ADDRESS]
     )
   })
 })

--- a/test/deploymentUtils.js
+++ b/test/deploymentUtils.js
@@ -1,17 +1,20 @@
 const { ZERO_ADDRESS } = require('./utils')
 const CMTAT_STANDALONE = artifacts.require('CMTAT_STANDALONE')
+const CMTAT_STANDALONE_SNAPSHOT = artifacts.require('CMTATSnapshotStandaloneTest')
 const CMTAT_PROXY = artifacts.require('CMTAT_PROXY')
 const CMTAT_PROXY_SNAPSHOT = artifacts.require('CMTATSnapshotProxyTest')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
+const { time } = require('@openzeppelin/test-helpers')
 const { ethers, upgrades } = require('hardhat')
-// const { ethers, upgrades } = require('@nomicfoundation/hardhat-ethers');
 const DEPLOYMENT_FLAG = 5
 const DEPLOYMENT_DECIMAL = 0
 
 async function deployCMTATStandalone (_, admin, deployerAddress) {
+  const delay = web3.utils.toBN(time.duration.days(3))
   const cmtat = await CMTAT_STANDALONE.new(
     _,
     admin,
+    delay,
     'CMTA Token',
     'CMTAT',
     DEPLOYMENT_DECIMAL,
@@ -29,6 +32,7 @@ async function deployCMTATStandaloneWithParameter (
   deployerAddress,
   forwarderIrrevocable,
   admin,
+  initialDelayToAcceptAdminRole,
   nameIrrevocable,
   symbolIrrevocable,
   decimalsIrrevocable,
@@ -41,6 +45,7 @@ async function deployCMTATStandaloneWithParameter (
   const cmtat = await CMTAT_STANDALONE.new(
     forwarderIrrevocable,
     admin,
+    initialDelayToAcceptAdminRole,
     nameIrrevocable,
     symbolIrrevocable,
     decimalsIrrevocable,
@@ -49,6 +54,25 @@ async function deployCMTATStandaloneWithParameter (
     ruleEngine_,
     information_,
     flag_,
+    { from: deployerAddress }
+  )
+  return cmtat
+}
+
+async function deployCMTATStandaloneWithSnapshot (_, admin, deployerAddress) {
+  const delay = web3.utils.toBN(time.duration.days(3))
+  const cmtat = await CMTAT_STANDALONE_SNAPSHOT.new(
+    _,
+    admin,
+    delay,
+    'CMTA Token',
+    'CMTAT',
+    DEPLOYMENT_DECIMAL,
+    'CMTAT_ISIN',
+    'https://cmta.ch',
+    ZERO_ADDRESS,
+    'CMTAT_info',
+    DEPLOYMENT_FLAG,
     { from: deployerAddress }
   )
   return cmtat
@@ -63,6 +87,7 @@ async function deployCMTATProxy (_, admin, deployerAddress) {
     ETHERS_CMTAT_PROXY_FACTORY,
     [
       admin,
+      BigInt(time.duration.days(3)),
       'CMTA Token',
       'CMTAT',
       DEPLOYMENT_DECIMAL,
@@ -90,10 +115,12 @@ async function deployCMTATProxyWithSnapshot (_, admin, deployerAddress) {
   const ETHERS_CMTAT_PROXY_FACTORY = await ethers.getContractFactory(
     'CMTATSnapshotProxyTest'
   )
+  const delayTime = BigInt(time.duration.days(3))
   const ETHERS_CMTAT_PROXY = await upgrades.deployProxy(
     ETHERS_CMTAT_PROXY_FACTORY,
     [
       admin,
+      delayTime,
       'CMTA Token',
       'CMTAT',
       DEPLOYMENT_DECIMAL,
@@ -125,6 +152,7 @@ async function deployCMTATProxyWithKillTest (_, admin, deployerAddress) {
     ETHERS_CMTAT_PROXY_FACTORY,
     [
       admin,
+      BigInt(time.duration.days(3)),
       'CMTA Token',
       'CMTAT',
       DEPLOYMENT_DECIMAL,
@@ -151,6 +179,7 @@ async function deployCMTATProxyWithParameter (
   deployerAddress,
   forwarderIrrevocable,
   admin,
+  initialDelayToAcceptAdminRole,
   nameIrrevocable,
   symbolIrrevocable,
   decimalsIrrevocable,
@@ -168,6 +197,7 @@ async function deployCMTATProxyWithParameter (
     ETHERS_CMTAT_PROXY_FACTORY,
     [
       admin,
+      initialDelayToAcceptAdminRole,
       nameIrrevocable,
       symbolIrrevocable,
       decimalsIrrevocable,
@@ -192,6 +222,7 @@ async function deployCMTATProxyWithParameter (
 
 module.exports = {
   deployCMTATStandalone,
+  deployCMTATStandaloneWithSnapshot,
   deployCMTATProxy,
   deployCMTATProxyWithSnapshot,
   deployCMTATProxyWithKillTest,

--- a/test/proxy/general/KillImplementation.test.js
+++ b/test/proxy/general/KillImplementation.test.js
@@ -9,8 +9,7 @@ const {
   expectRevertCustomError
 } = require('../../../openzeppelin-contracts-upgradeable/test/helpers/customError.js')
 const { should } = require('chai').should()
-const { deployProxy, erc1967 } = require('@openzeppelin/truffle-upgrades')
-const { ethers, upgrades } = require('hardhat')
+const { upgrades } = require('hardhat')
 const CMTAT_KILL_TEST = artifacts.require('CMTAT_KILL_TEST')
 
 contract('Proxy - Security Test', function ([_, admin, deployerAddress]) {

--- a/test/proxy/general/Proxy.test.js
+++ b/test/proxy/general/Proxy.test.js
@@ -1,11 +1,5 @@
-const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers')
+const { time } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
-
-const {
-  deployProxy,
-  upgradeProxy,
-  erc1967
-} = require('@openzeppelin/truffle-upgrades')
 const {
   expectRevertCustomError
 } = require('../../../openzeppelin-contracts-upgradeable/test/helpers/customError.js')
@@ -14,7 +8,7 @@ const { DEFAULT_ADMIN_ROLE } = require('../../utils')
 const { ZERO_ADDRESS } = require('../../utils')
 const DECIMAL = 0
 const { deployCMTATProxy, DEPLOYMENT_FLAG } = require('../../deploymentUtils')
-const { ethers, upgrades } = require('hardhat')
+const { upgrades } = require('hardhat')
 contract(
   'Proxy - Security Test',
   function ([_, admin, attacker, deployerAddress]) {
@@ -38,6 +32,7 @@ contract(
         await expectRevertCustomError(
           this.implementationContract.initialize(
             attacker,
+            BigInt(time.duration.days(3)),
             'CMTA Token',
             'CMTAT',
             DECIMAL,
@@ -62,6 +57,7 @@ contract(
         await expectRevertCustomError(
           this.implementationContract.initialize(
             attacker,
+            BigInt(time.duration.days(3)),
             'CMTA Token',
             'CMTAT',
             DECIMAL,

--- a/test/proxy/general/UpgradeProxy.test.js
+++ b/test/proxy/general/UpgradeProxy.test.js
@@ -1,4 +1,4 @@
-const { BN } = require('@openzeppelin/test-helpers')
+const { BN, time } = require('@openzeppelin/test-helpers')
 const { should } = require('chai').should()
 const { ZERO_ADDRESS } = require('../../utils')
 const {
@@ -29,6 +29,7 @@ contract(
         ETHERS_CMTAT_PROXY_FACTORY,
         [
           admin,
+          BigInt(time.duration.days(3)),
           'CMTA Token',
           'CMTAT',
           DEPLOYMENT_DECIMAL,

--- a/test/proxy/modules/MetaTxModule.test.js
+++ b/test/proxy/modules/MetaTxModule.test.js
@@ -1,3 +1,4 @@
+const { time } = require('@openzeppelin/test-helpers')
 const { deployProxy } = require('@openzeppelin/truffle-upgrades')
 const CMTAT = artifacts.require('CMTAT_PROXY')
 const MinimalForwarderMock = artifacts.require('MinimalForwarderMock')
@@ -13,10 +14,12 @@ contract(
       const DECIMAL = 0
       this.forwarder = await MinimalForwarderMock.new()
       await this.forwarder.initialize(ERC2771ForwarderDomain)
+      const delayTime = BigInt(time.duration.days(3))
       this.cmtat = await deployCMTATProxyWithParameter(
         deployerAddress,
         this.forwarder.address,
         admin,
+        delayTime,
         'CMTA Token',
         'CMTAT',
         DECIMAL,

--- a/test/proxy/modules/ValidationModule/ValidationModuleConstructor.test.js
+++ b/test/proxy/modules/ValidationModule/ValidationModuleConstructor.test.js
@@ -1,5 +1,4 @@
-const CMTAT = artifacts.require('CMTAT_PROXY')
-const { deployProxy } = require('@openzeppelin/truffle-upgrades')
+const { time } = require('@openzeppelin/test-helpers')
 const ValidationModuleCommon = require('../../../common/ValidationModule/ValidationModuleCommon')
 const { deployCMTATProxyWithParameter } = require('../../../deploymentUtils')
 const RuleEngineMock = artifacts.require('RuleEngineMock')
@@ -14,10 +13,13 @@ contract(
       this.flag = 5
       const DECIMAL = 0
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
+      const delayTime = BigInt(time.duration.days(3))
+      console.log(delayTime)
       this.cmtat = await deployCMTATProxyWithParameter(
         deployerAddress,
         _,
         admin,
+        delayTime,
         'CMTA Token',
         'CMTAT',
         DECIMAL,

--- a/test/standard/modules/MetaTxModule.test.js
+++ b/test/standard/modules/MetaTxModule.test.js
@@ -1,4 +1,4 @@
-const CMTAT = artifacts.require('CMTAT_STANDALONE')
+const { time } = require('@openzeppelin/test-helpers')
 const MinimalForwarderMock = artifacts.require('MinimalForwarderMock')
 const MetaTxModuleCommon = require('../../common/MetaTxModuleCommon')
 const { deployCMTATStandaloneWithParameter } = require('../../deploymentUtils')
@@ -16,6 +16,7 @@ contract(
         deployerAddress,
         this.forwarder.address,
         admin,
+        web3.utils.toBN(time.duration.days(3)),
         'CMTA Token',
         'CMTAT',
         DECIMAL,

--- a/test/standard/modules/SnapshotModule.test.js
+++ b/test/standard/modules/SnapshotModule.test.js
@@ -6,26 +6,12 @@ const SnapshotModuleCommonGetNextSnapshot = require('../../common/SnapshotModule
 const SnapshotModuleMultiplePlannedTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleMultiplePlannedTest')
 const SnapshotModuleOnePlannedSnapshotTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleOnePlannedSnapshotTest')
 const SnapshotModuleZeroPlannedSnapshotTest = require('../../common/SnapshotModuleCommon/global/SnapshotModuleZeroPlannedSnapshot')
-const { ZERO_ADDRESS } = require('../../utils')
-const DECIMAL = 0
+const { deployCMTATStandaloneWithSnapshot } = require('../../deploymentUtils')
 contract(
   'Standard - SnapshotModule',
-  function ([_, admin, address1, address2, address3, randomDeployer]) {
+  function ([_, admin, address1, address2, address3, deployerAddress]) {
     beforeEach(async function () {
-      this.flag = 5
-      this.cmtat = await CMTAT.new(
-        _,
-        admin,
-        'CMTA Token',
-        'CMTAT',
-        DECIMAL,
-        'CMTAT_ISIN',
-        'https://cmta.ch',
-        ZERO_ADDRESS,
-        'CMTAT_info',
-        this.flag,
-        { from: randomDeployer }
-      )
+      this.cmtat = await deployCMTATStandaloneWithSnapshot(_, admin, deployerAddress)
     })
     SnapshotModuleMultiplePlannedTest(admin, address1, address2, address3)
     SnapshotModuleOnePlannedSnapshotTest(admin, address1, address2, address3)

--- a/test/standard/modules/ValidationModule/ValidationModuleConstructor.test.js
+++ b/test/standard/modules/ValidationModule/ValidationModuleConstructor.test.js
@@ -1,3 +1,4 @@
+const { time } = require('@openzeppelin/test-helpers')
 const ValidationModuleCommon = require('../../../common/ValidationModule/ValidationModuleCommon')
 const RuleEngineMock = artifacts.require('RuleEngineMock')
 const {
@@ -13,10 +14,12 @@ contract(
       this.flag = 5
       const DECIMAL = 0
       this.ruleEngineMock = await RuleEngineMock.new({ from: admin })
+      const delayTime = BigInt(time.duration.days(3))
       this.cmtat = await deployCMTATStandaloneWithParameter(
         deployerAddress,
         _,
         admin,
+        delayTime,
         'CMTA Token',
         'CMTAT',
         DECIMAL,


### PR DESCRIPTION
Use AccessControlDefaultAdminRules inside the Authorization module
This contract implements the following risk mitigations on top of [AccessControl](https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControl):

- Only one account holds the DEFAULT_ADMIN_ROLE since deployment until it’s potentially renounced.

- Enforces a 2-step process to transfer the DEFAULT_ADMIN_ROLE to another account.

- Enforces a configurable delay between the two steps, with the ability to cancel before the transfer is accepted.

The delay can be changed by scheduling, see [changeDefaultAdminDelay](https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControlDefaultAdminRules-changeDefaultAdminDelay-uint48-).

It is not possible to use another role to manage the DEFAULT_ADMIN_ROLE.
see [https://docs.openzeppelin.com](https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControlDefaultAdminRules)

closes #192 

