### PR TITLE
Use calldata instead of memory

### DIFF
--- a/contracts/modules/internal/ERC20SnapshotModuleInternal.sol
+++ b/contracts/modules/internal/ERC20SnapshotModuleInternal.sol
@@ -67,8 +67,8 @@ abstract contract ERC20SnapshotModuleInternal is ERC20Upgradeable {
      * @dev Initializes the contract
      */
     function __ERC20Snapshot_init(
-        string calldata name_,
-        string calldata symbol_
+        string memory name_,
+        string memory symbol_
     ) internal onlyInitializing {
         __Context_init_unchained();
         __ERC20_init(name_, symbol_);

--- a/contracts/modules/wrapper/core/BaseModule.sol
+++ b/contracts/modules/wrapper/core/BaseModule.sol
@@ -75,7 +75,7 @@ abstract contract BaseModule is AuthorizationModule {
     @notice the tokenId will be changed even if the new value is the same as the current one
     */
     function setTokenId(
-        string memory tokenId_
+        string calldata tokenId_
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         tokenId = tokenId_;
         emit TokenId(tokenId_, tokenId_);
@@ -85,7 +85,7 @@ abstract contract BaseModule is AuthorizationModule {
     @notice The terms will be changed even if the new value is the same as the current one
     */
     function setTerms(
-        string memory terms_
+        string calldata terms_
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         terms = terms_;
         emit Term(terms_, terms_);
@@ -95,7 +95,7 @@ abstract contract BaseModule is AuthorizationModule {
     @notice The information will be changed even if the new value is the same as the current one
     */
     function setInformation(
-        string memory information_
+        string calldata information_
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
         information = information_;
         emit Information(information_, information_);

--- a/contracts/modules/wrapper/core/ERC20BurnModule.sol
+++ b/contracts/modules/wrapper/core/ERC20BurnModule.sol
@@ -50,7 +50,7 @@ abstract contract ERC20BurnModule is ERC20Upgradeable, AuthorizationModule {
     function forceBurn(
         address account,
         uint256 value,
-        string memory reason
+        string calldata reason
     ) public onlyRole(BURNER_ROLE) {
         _burn(account, value);
         emit Burn(account, value, reason);
@@ -73,7 +73,7 @@ abstract contract ERC20BurnModule is ERC20Upgradeable, AuthorizationModule {
     function forceBurnBatch(
         address[] calldata accounts,
         uint256[] calldata values,
-        string memory reason
+        string calldata reason
     ) public onlyRole(BURNER_ROLE) {
         if (accounts.length == 0) {
             revert Errors.CMTAT_BurnModule_EmptyAccounts();

--- a/contracts/modules/wrapper/extensions/DebtModule/DebtBaseModule.sol
+++ b/contracts/modules/wrapper/extensions/DebtModule/DebtBaseModule.sol
@@ -82,24 +82,8 @@ abstract contract DebtBaseModule is
     @notice Set all attributes of debt
     The values of all attributes will be changed even if the new values are the same as the current ones
     */
-    function setDebt(DebtBase memory debt_) public onlyRole(DEBT_ROLE) {
-        // setGuarantor
-        debt = (
-            DebtBase(
-                debt_.interestRate,
-                debt_.parValue,
-                debt_.guarantor,
-                debt_.bondHolder,
-                debt_.maturityDate,
-                debt_.interestScheduleFormat,
-                debt_.interestPaymentDate,
-                debt_.dayCountConvention,
-                debt_.businessDayConvention,
-                debt_.publicHolidaysCalendar,
-                debt_.issuanceDate,
-                debt_.couponFrequency
-            )
-        );
+    function setDebt(DebtBase calldata debt_) public onlyRole(DEBT_ROLE) {
+        debt = debt_;
         emit InterestRate(debt_.interestRate);
         emit ParValue(debt_.parValue);
         emit Guarantor(debt_.guarantor, debt_.guarantor);


### PR DESCRIPTION
close #224
Use calldata instead of memory when it is possible

In ERC20Snapshot_init, use memory instead of calldata since the ERC20 contract from OpenZeppelin uses memory
