### PR TITLE
fix: reject self forced-transfer that mutates frozen state without moving assets (#380)

### DIFF
--- a/contracts/mocks/CMTATMsgDataMock.sol
+++ b/contracts/mocks/CMTATMsgDataMock.sol
@@ -72,8 +72,11 @@ contract CMTATUpgradeableERC1363MsgDataMock is CMTATUpgradeableERC1363 {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address forwarderIrrevocable) CMTATUpgradeableERC1363(forwarderIrrevocable) {}
 
-    function getMsgData() external view returns (bytes memory) {
-        return _msgData();
+    // Returns a fixed-size digest of _msgData() rather than the dynamically encoded
+    // bytes, so this ERC-1363 mock stays within the EIP-170 code size limit. keccak256
+    // still distinguishes stripped from unstripped calldata, which is the behavior under test.
+    function getMsgData() external view returns (bytes32) {
+        return keccak256(_msgData());
     }
 }
 

--- a/contracts/modules/internal/ERC20EnforcementModuleInternal.sol
+++ b/contracts/modules/internal/ERC20EnforcementModuleInternal.sol
@@ -19,6 +19,7 @@ abstract contract ERC20EnforcementModuleInternal is ERC20Upgradeable, IERC7943Fu
     error CMTAT_ERC20EnforcementModule_ValueExceedsAvailableBalance();
     error CMTAT_ERC20EnforcementModule_ValueExceedsFrozenBalance(); 
     error CMTAT_ERC20EnforcementModule_ValueEqualCurrentFrozenTokens(); 
+    error CMTAT_ERC20EnforcementModule_SelfForcedTransferNotAllowed();
     /* ============ ERC-7201 ============ */
     // keccak256(abi.encode(uint256(keccak256("CMTAT.storage.ERC20EnforcementModule")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant ERC20EnforcementModuleStorageLocation = 0x9d8059a24cb596f1948a937c2c163cf14465c2a24abfd3cd009eec4ac4c39800;
@@ -101,6 +102,12 @@ abstract contract ERC20EnforcementModuleInternal is ERC20Upgradeable, IERC7943Fu
     }
 
     function _forcedTransfer(address from, address to, uint256 value) internal virtual {
+        // A self forced-transfer moves no assets but would otherwise mutate frozen
+        // state, and potentially allowance state. Reject it before any side effects.
+        // See CMTA/CMTAT#380.
+        if (from == to) {
+            revert CMTAT_ERC20EnforcementModule_SelfForcedTransferNotAllowed();
+        }
         _unfreezeTokens(from, value);
         if(to == address(0)){
             ERC20Upgradeable._burn(from, value);

--- a/test/common/ERC20EnforcementModuleCommon.js
+++ b/test/common/ERC20EnforcementModuleCommon.js
@@ -312,6 +312,28 @@ function ERC20EnforcementModuleCommon () {
       )
     })
 
+    // Regression test for CMTA/CMTAT#380: a self forced-transfer must not
+    // silently unfreeze tokens. address1 already holds 50 from the beforeEach.
+    it('testCannotSelfForcedTransferToUnfreezeTokens', async function () {
+      await freezePartialTokensCompat(this, this.admin, this.address1, INITIAL_BALANCE, REASON)
+      expect(await this.cmtat.getFrozenTokens(this.address1)).to.equal(INITIAL_BALANCE.toString())
+
+      // A self forced-transfer of the full balance moves nothing. Before the fix
+      // it still ran the excess-frozen update and released every frozen token.
+      await expect(
+        this.cmtat
+          .connect(this.admin)
+          .forcedTransfer(this.address1, this.address1, INITIAL_BALANCE)
+      ).to.be.revertedWithCustomError(
+        this.cmtat,
+        'CMTAT_ERC20EnforcementModule_SelfForcedTransferNotAllowed'
+      )
+
+      // The rejected call leaves frozen amount and balance untouched.
+      expect(await this.cmtat.getFrozenTokens(this.address1)).to.equal(INITIAL_BALANCE.toString())
+      expect(await this.cmtat.balanceOf(this.address1)).to.equal(INITIAL_BALANCE.toString())
+    })
+
     it('testCannotNonAdminTransferFunds', async function () {
       // Act
       await expect(

--- a/test/standard/modules/MetaTxMsgDataERC1363.test.js
+++ b/test/standard/modules/MetaTxMsgDataERC1363.test.js
@@ -33,7 +33,7 @@ describe('Standard - MetaTxModule - _msgData (CMTATBaseERC1363)', function () {
   it('returns correct msgData for direct call', async function () {
     const expectedData = this.cmtat.interface.encodeFunctionData('getMsgData')
     const result = await this.cmtat.getMsgData.staticCall()
-    expect(result).to.equal(expectedData)
+    expect(result).to.equal(ethers.keccak256(expectedData))
   })
 
   it('returns correct msgData for trusted forwarder calldata shape', async function () {
@@ -44,7 +44,6 @@ describe('Standard - MetaTxModule - _msgData (CMTATBaseERC1363)', function () {
       from: this.forwarder.target,
       data: appendedData
     })
-    const [decoded] = ethers.AbiCoder.defaultAbiCoder().decode(['bytes'], returnData)
-    expect(decoded).to.equal(data)
+    expect(returnData).to.equal(ethers.keccak256(data))
   })
 })


### PR DESCRIPTION
## Summary

`forcedTransfer(from == to)` moves no assets, but still runs `_unfreezeTokens(from, value)` before the (no-op) transfer, so it reduces `frozenTokens[from]`. With a self-allowance set it can also reduce `allowance(from, from)`. A self forced-transfer therefore acts as a pure side effect on frozen (and allowance) state, even though a function documented as transferring assets moved nothing.

Fixes #380.

## Scope of the impact

In stock CMTAT `forcedTransfer` is authorized by `DEFAULT_ADMIN_ROLE`, and the `hasRole` override treats the default admin as holding every role, so the authorized caller already has freeze and unfreeze authority. The immediate privilege-separation impact is therefore limited for the reference deployment. The change is best read as a CMTAT invariant and semantic / audit-trail hardening: a call that transfers no assets should not mutate frozen or allowance state. It also matters for derived deployments that use a customized authorization model with genuinely separate force-transfer and freezing authorities.

This is consistent with ERC-7943 rather than strictly required by it. The single-party versus multi-party distinction in ERC-7943 governs whether an actual forced transfer may consume frozen assets. A `from == to` call consumes nothing, so rejecting it preserves single-party behaviour for every real transfer or burn while removing the pure-unfreeze side channel.

## Change

- `ERC20EnforcementModuleInternal._forcedTransfer`: reject `from == to` before any side effect, with a new module-level error `CMTAT_ERC20EnforcementModule_SelfForcedTransferNotAllowed` (no argument, matching the existing `CMTAT_ERC20EnforcementModule_*` errors). The guard sits in the shared internal function, so it also covers the ERC-7551 `bytes`-data overload, which delegates here.
- `test/common/ERC20EnforcementModuleCommon.js`: regression test that freezes the whole balance, asserts the self forced-transfer reverts, and checks that the frozen amount and balance are unchanged. I confirmed it fails without the guard.

## Contract size

The guard adds a few bytes to the enforcement module. The ERC-1363 deployment variants sit close to the EIP-170 limit, and the `_msgData` test mock was right at it, so the added bytes pushed `CMTATUpgradeableERC1363MsgDataMock` past 24576 bytes at deploy time.

Rather than weaken the fix or disable the size check, I shrank that test probe: `getMsgData()` now returns `keccak256(_msgData())` (fixed size) instead of the dynamically encoded `bytes`. That still distinguishes stripped from unstripped forwarder calldata, which is the behaviour under test, and the ERC-1363 msgData test was updated to match.

Exact deployed sizes after the change (limit 24576 bytes):

| Contract | Deployed (bytes) | Headroom (bytes) |
|---|---|---|
| CMTATStandaloneERC1363 | 24426 | 150 |
| CMTATUpgradeableERC1363 | 24426 | 150 |
| CMTATUpgradeableERC1363MsgDataMock (revised) | 24549 | 27 |

## Tests

Full Hardhat suite: 5651 passing, 0 failing.

## Alternative

A non-reverting no-op could prevent the state mutation, but it would retain ambiguous success and event semantics (the call would still succeed, and could emit `Transfer` / `ForcedTransfer`, despite moving nothing). The explicit revert is therefore preferred. Happy to revisit if you would rather avoid the guard's bytes.
